### PR TITLE
Slider fixes for older versions of IE

### DIFF
--- a/inc/css/black.css
+++ b/inc/css/black.css
@@ -4703,6 +4703,8 @@ input[type="submit"].btn.btn-mini {
 }
 .carousel-inner > .active {
   left: 0;
+  /* Fix slider in IE */
+  z-index: 9; 
 }
 .carousel-inner > .next,
 .carousel-inner > .prev {
@@ -7591,6 +7593,8 @@ h2.site-description {
   padding: 5%;
   line-height: 14px;
   vertical-align: middle;
+  /* fix for IE to align the grey box to center */
+  top: 25%;
   display: inline-block;
   position: relative;
   margin-left: 11%;

--- a/inc/css/blue.css
+++ b/inc/css/blue.css
@@ -4703,6 +4703,8 @@ input[type="submit"].btn.btn-mini {
 }
 .carousel-inner > .active {
   left: 0;
+  /* Fix slider in IE */
+  z-index: 9; 
 }
 .carousel-inner > .next,
 .carousel-inner > .prev {
@@ -7591,6 +7593,8 @@ h2.site-description {
   padding: 5%;
   line-height: 14px;
   vertical-align: middle;
+  /* fix for IE to align the grey box to center */
+  top: 25%;
   display: inline-block;
   position: relative;
   margin-left: 11%;

--- a/inc/css/green.css
+++ b/inc/css/green.css
@@ -4703,6 +4703,8 @@ input[type="submit"].btn.btn-mini {
 }
 .carousel-inner > .active {
   left: 0;
+  /* Fix slider in IE */
+  z-index: 9; 
 }
 .carousel-inner > .next,
 .carousel-inner > .prev {
@@ -7591,6 +7593,8 @@ h2.site-description {
   padding: 5%;
   line-height: 14px;
   vertical-align: middle;
+  /* fix for IE to align the grey box to center */
+  top: 25%;
   display: inline-block;
   position: relative;
   margin-left: 11%;

--- a/inc/css/grey.css
+++ b/inc/css/grey.css
@@ -4703,6 +4703,8 @@ input[type="submit"].btn.btn-mini {
 }
 .carousel-inner > .active {
   left: 0;
+  /* Fix slider in IE */
+  z-index: 9; 
 }
 .carousel-inner > .next,
 .carousel-inner > .prev {
@@ -7591,6 +7593,8 @@ h2.site-description {
   padding: 5%;
   line-height: 14px;
   vertical-align: middle;
+  /* fix for IE to align the grey box to center */
+  top: 25%;
   display: inline-block;
   position: relative;
   margin-left: 11%;

--- a/inc/css/orange.css
+++ b/inc/css/orange.css
@@ -4703,6 +4703,8 @@ input[type="submit"].btn.btn-mini {
 }
 .carousel-inner > .active {
   left: 0;
+  /* Fix slider in IE */
+  z-index: 9; 
 }
 .carousel-inner > .next,
 .carousel-inner > .prev {
@@ -7591,6 +7593,8 @@ h2.site-description {
   padding: 5%;
   line-height: 14px;
   vertical-align: middle;
+  /* fix for IE to align the grey box to center */
+  top: 25%;
   display: inline-block;
   position: relative;
   margin-left: 11%;

--- a/inc/css/purple.css
+++ b/inc/css/purple.css
@@ -4703,6 +4703,8 @@ input[type="submit"].btn.btn-mini {
 }
 .carousel-inner > .active {
   left: 0;
+  /* Fix slider in IE */
+  z-index: 9; 
 }
 .carousel-inner > .next,
 .carousel-inner > .prev {
@@ -7591,6 +7593,8 @@ h2.site-description {
   padding: 5%;
   line-height: 14px;
   vertical-align: middle;
+  /* fix for IE to align the grey box to center */
+  top: 25%;
   display: inline-block;
   position: relative;
   margin-left: 11%;

--- a/inc/css/red.css
+++ b/inc/css/red.css
@@ -4703,6 +4703,8 @@ input[type="submit"].btn.btn-mini {
 }
 .carousel-inner > .active {
   left: 0;
+  /* Fix slider in IE */
+  z-index: 9; 
 }
 .carousel-inner > .next,
 .carousel-inner > .prev {
@@ -7591,6 +7593,8 @@ h2.site-description {
   padding: 5%;
   line-height: 14px;
   vertical-align: middle;
+  /* fix for IE to align the grey box to center */
+  top: 25%;
   display: inline-block;
   position: relative;
   margin-left: 11%;

--- a/inc/css/yellow.css
+++ b/inc/css/yellow.css
@@ -4703,6 +4703,8 @@ input[type="submit"].btn.btn-mini {
 }
 .carousel-inner > .active {
   left: 0;
+  /* Fix slider in IE */
+  z-index: 9; 
 }
 .carousel-inner > .next,
 .carousel-inner > .prev {
@@ -7591,6 +7593,8 @@ h2.site-description {
   padding: 5%;
   line-height: 14px;
   vertical-align: middle;
+  /* fix for IE to align the grey box to center */
+  top: 25%;
   display: inline-block;
   position: relative;
   margin-left: 11%;


### PR DESCRIPTION
Added z-index to active slide to fix slides falling below each other on
transition

Added 'top: 25%' to center align slide caption on older versions of IE
