### PR TITLE
Fix ipad issue when dropdown menu item parent hasn't href attr

### DIFF
--- a/inc/parts/class-header-nav_walker.php
+++ b/inc/parts/class-header-nav_walker.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'TC_nav_walker' ) ) :
         if ( $item->is_dropdown && ( $depth === 0)) {
           //makes top menu not clickable (default bootstrap behaviour)
           $search         = '<a';
-          $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( tc__f( '__get_option' , 'tc_menu_type' ) ) ) ? $search : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
+          $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( tc__f( '__get_option' , 'tc_menu_type' ) ) ) ? $search : sprintf('<a class="dropdown-toggle" data-toggle="dropdown" data-target="#" %1$s', strpos($item_html, 'href=') ? '' : 'href="#"');
           $replace        = apply_filters( 'tc_menu_open_on_click', $replace , $search );
           $item_html      = str_replace( $search , $replace , $item_html);
 


### PR DESCRIPTION
( Finally, probably, I succeeded :P )
This will add the attr href="#" to those parent menu items which doesn't have it, when customizr is loaded on mobile devs.
