### PR TITLE
Fix click on slide's call to action buttons in mobile devs

### DIFF
--- a/inc/assets/js/main.js
+++ b/inc/assets/js/main.js
@@ -314,6 +314,13 @@ jQuery(function ($) {
 
     //Slider swipe support with hammer.js
     if ( 'function' == typeof($.fn.hammer) ) {
+        
+        //prevent propagation event from sensible children
+        $(".carousel input, .carousel button, .carousel textarea, .carousel select, .carousel a").
+            on("touchstart touchmove", function(ev) {
+                ev.stopPropagation();
+        });
+
         $('.carousel' ).each( function() {
             $(this).hammer().on('swipeleft tap', function() {
                 $(this).carousel('next');


### PR DESCRIPTION
(Sorry for indentation issue again)
This should fix the issue: https://wordpress.org/support/topic/any-bugs-in-customizr-328?replies=27#post-6275268
Tested with a samsung tablet, seems to work.
Extended the list of children which don't have to propagate the event also to other, at the moment not available, 
elements (thinking about the use of shortcodes into slider caption).
source: https://github.com/hammerjs/hammer.js/issues/439 jtangelder's comment.
