### PR TITLE
Fix dropdown on click for multitier menus

### DIFF
--- a/inc/assets/js/main.js
+++ b/inc/assets/js/main.js
@@ -330,6 +330,39 @@ jQuery(function ($) {
             });
         });
     }
+
+    //Handle dropdown on click for multi-tier menus
+    var dropdown_ahrefs = $('.tc-open-on-click .menu-item.menu-item-has-children > a[href!="#"]'),
+    dropdown_submenus = $('.tc-open-on-click .dropdown .dropdown-submenu');
+            
+    // go to the link if submenu is already opened
+    dropdown_ahrefs.on('tap click', function(evt){
+        if ( $(this).next('.dropdown-menu').is(':visible') ){
+            window.location = $(this).attr('href');
+        }
+    });
+    // make sub-submenus dropdown on click work
+    // do we want restrict this in "non-mobile menu"?
+    // for "non-mobile menu" I mean when btn-navbar is visible
+    // or if you prefer when window width < 980px (-scrollbar)
+    dropdown_submenus.each(function(){
+        var $parent = $(this),
+            $children = $parent.children('[data-toggle="dropdown"]');
+        $children.on('tap click', function(){
+            var submenu = $(this).next('.dropdown-menu'),
+                openthis = false;
+            if ( ! $parent.hasClass('open') )
+                openthis = true;
+            // close opened submenus
+            $($parent.parent()).children('.dropdown-submenu').each(function(){
+                $(this).removeClass('open');
+            });
+            if ( openthis )
+                $parent.addClass('open');
+
+            return false;
+        });
+    });
 });
 
 

--- a/inc/parts/class-header-menu.php
+++ b/inc/parts/class-header-menu.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
       function tc_set_menu_style_options( $_classes ) {
         $_classes = ( ! wp_is_mobile() && 0 != esc_attr( tc__f( '__get_option', 'tc_menu_submenu_fade_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-fade' ) ) : $_classes;
         $_classes = ( 0 != esc_attr( tc__f( '__get_option', 'tc_menu_submenu_item_move_effect') ) ) ? array_merge( $_classes, array( 'tc-submenu-move' ) ) : $_classes;
-        $_classes = ( 'hover' == esc_attr( tc__f( '__get_option' , 'tc_menu_type' ) ) ) ? array_merge( $_classes, array( 'tc-open-on-hover' ) ) : array_merge( $_classes, array( 'tc-open-on-click' ) );
+        $_classes = ( ! wp_is_mobile() && 'hover' == esc_attr( tc__f( '__get_option' , 'tc_menu_type' ) ) ) ? array_merge( $_classes, array( 'tc-open-on-hover' ) ) : array_merge( $_classes, array( 'tc-open-on-click' ) );
         return array_merge( $_classes, array(esc_attr( tc__f( '__get_option', 'tc_menu_position') ) ) );
       }
 

--- a/inc/parts/class-header-nav_walker.php
+++ b/inc/parts/class-header-nav_walker.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'TC_nav_walker' ) ) :
         $item_html = '';
         parent::start_el( $item_html, $item, $depth, $args);
 
-        if ( $item->is_dropdown && ( $depth === 0)) {
+        if ( $item->is_dropdown ) {
           //makes top menu not clickable (default bootstrap behaviour)
           $search         = '<a';
           $replace        = ( ! wp_is_mobile() && 'hover' == esc_attr( tc__f( '__get_option' , 'tc_menu_type' ) ) ) ? $search : '<a class="dropdown-toggle" data-toggle="dropdown" data-target="#"';
@@ -43,7 +43,8 @@ if ( ! class_exists( 'TC_nav_walker' ) ) :
           $item_html      = str_replace( $search , $replace , $item_html);
 
           //adds arrows down
-          $item_html      = str_replace( '</a>' , ' <b class="caret"></b></a>' , $item_html);
+          if ( $depth === 0 )
+              $item_html      = str_replace( '</a>' , ' <b class="caret"></b></a>' , $item_html);
         }
         elseif (stristr( $item_html, 'li class="divider' )) {
           $item_html = preg_replace( '/<a[^>]*>.*?<\/a>/iU' , '' , $item_html);


### PR DESCRIPTION
This is quite of an hack to handle dropdown on click for multitier menus.
Basically this should solve:
1) Parent menu items with own href != "#" again reachable in mobile devs (with mobile menu)
2) Dropdown on click for menu items with depht > 0
4) In mobile devs with width => 980px (i-pad, for example), when you have a situation 
like the one in 1) the first click will open the submenu, the second will take you to the href

I've tested it:
a) using dropdown on click menu
b) a) or dropdown on hover, with a samsung tablet (width < 980 px)
c) a) or dropdown on hover,  ipad with google-chrome emulator.
if you wanna make tests with gc emulator and mobile you should add this custom css
@media (min-width: 980px){
    .tc-open-on-click .dropdown-submenu:hover>.dropdown-menu {
        display: none;
    }
}
this 'cause the emulator still catches the 'hover' event.

Further tests may be required.
