### PR TITLE
Fix: 'hide' tc-cta when in sub-panel

### DIFF
--- a/inc/admin/css/theme-customizer-control.css
+++ b/inc/admin/css/theme-customizer-control.css
@@ -718,3 +718,6 @@ li#customize-control-tc_theme_options-tc_custom_css textarea {
   -webkit-box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.3);
   box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.3);
 }
+.in-sub-panel .tc-cta-wrap {
+  left: -300px;  
+}


### PR DESCRIPTION
Same code used to hide #customize-info .
Also you might want to use the same transitions effects. You can see them here:
# customize-info {

position: relative;
left: 0;
-webkit-transition: left ease-in-out .18s;
transition: left ease-in-out .18s;
}
