### PR TITLE
Fix: dropdown menu on click

### DIFF
--- a/inc/assets/js/main.js
+++ b/inc/assets/js/main.js
@@ -360,10 +360,11 @@ jQuery(function ($) {
 
     // go to the link if submenu is already opened
     $dropdown_ahrefs.on('tap click', function(evt) {
-        if ( $(this).next('.dropdown-menu').css('visibility') != 'hidden' && 
-            ! $(this).parent().hasClass('dropdown-submenu' ||
-                $(this).next('.dropdown-menu').is(':visible') && 
-                $(this).parent().hasClass('dropdown-submenu') )
+        if ( ( $(this).next('.dropdown-menu').css('visibility') != 'hidden' && 
+                $(this).next('.dropdown-menu').is(':visible')  &&
+                ! $(this).parent().hasClass('dropdown-submenu') ) ||
+             ( $(this).next('.dropdown-menu').is(':visible') && 
+                $(this).parent().hasClass('dropdown-submenu') ) )
             window.location = $(this).attr('href');
     });
     // make sub-submenus dropdown on click work
@@ -372,7 +373,7 @@ jQuery(function ($) {
             $children = $parent.children('[data-toggle="dropdown"]');
         $children.on('tap click', function(){
             var submenu   = $(this).next('.dropdown-menu'),
-                openthis  = false,
+                openthis  = false;
             if ( ! $parent.hasClass('open') ) {
               openthis = true;
             }

--- a/inc/assets/js/main.js
+++ b/inc/assets/js/main.js
@@ -354,17 +354,17 @@ jQuery(function ($) {
     }
 
     //Handle dropdown on click for multi-tier menus
-    var $dropdown_ahrefs    = $('.tc-open-on-click .menu-item.menu-item-has-children > a'),
+    var $dropdown_ahrefs    = $('.tc-open-on-click .menu-item.menu-item-has-children > a[href!="#"]'),
         $dropdown_submenus  = $('.tc-open-on-click .dropdown .dropdown-submenu');
 
 
     // go to the link if submenu is already opened
-    $dropdown_ahrefs.not('a' , $dropdown_submenus).on('tap click', function(evt) {
-        var href = $(this).attr('href');
-        if ( '#' != href && '' !== href )
-          return;
-        if ( $(this).next('.dropdown-menu').is(':visible') )
-          window.location = href;
+    $dropdown_ahrefs.on('tap click', function(evt) {
+        if ( $(this).next('.dropdown-menu').css('visibility') != 'hidden' && 
+            ! $(this).parent().hasClass('dropdown-submenu' ||
+                $(this).next('.dropdown-menu').is(':visible') && 
+                $(this).parent().hasClass('dropdown-submenu') )
+            window.location = $(this).attr('href');
     });
     // make sub-submenus dropdown on click work
     $dropdown_submenus.each(function(){
@@ -373,12 +373,8 @@ jQuery(function ($) {
         $children.on('tap click', function(){
             var submenu   = $(this).next('.dropdown-menu'),
                 openthis  = false,
-                href      = $(this).attr('href');
             if ( ! $parent.hasClass('open') ) {
               openthis = true;
-            } else {
-              if ( '#' != href && '' !== href )
-                window.location = href;
             }
             // close opened submenus
             $($parent.parent()).children('.dropdown-submenu').each(function(){

--- a/inc/assets/less/tc_custom_responsive.less
+++ b/inc/assets/less/tc_custom_responsive.less
@@ -94,6 +94,9 @@
     -o-transition: all ease 0.241s;
     transition: all ease 0.241s;
   }
+  .tc-open-on-click .dropdown-submenu:hover > .dropdown.menu {
+    display: none;
+  }
   //expand submenus for tablets in landscape mode
   // .tc-is-mobile .navbar .nav li > ul ul {
   //   display: block;


### PR DESCRIPTION
This is a better version of my previous pull-request.
I discovered it didn't work when a first level menu item was a parent and a link to a content.
Was this the reason you changed it?
Also consider that the check on href!='' is useless since we force all parent menu-items to have
href="#"