### PR TITLE
Fix logo print: don't use wrong attachment's height & width

### DIFF
--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -597,6 +597,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
     * @return array Values with extension first and mime type.
     */
     function tc_check_filetype( $filename, $mimes = null ) {
+      $filename = basename( $filename );  
       if ( empty($mimes) )
         $mimes = get_allowed_mime_types();
       $type = false;

--- a/inc/parts/class-header-header_main.php
+++ b/inc/parts/class-header-header_main.php
@@ -168,8 +168,8 @@ if ( ! class_exists( 'TC_header_main' ) ) :
               $_attachement_id 	= $_logo_option;
               $_attachment_data 	= apply_filters( "tc{$logo_type}logo_attachment_img" , wp_get_attachment_image_src( $_logo_option , 'large' ) );
               $_logo_src 			= $_attachment_data[0];
-              $_width 			= isset($_attachment_data[1]) ? $_attachment_data[1] : $_width;
-              $_height 			= isset($_attachment_data[2]) ? $_attachment_data[2] : $_height;
+              $_width 			= ( isset($_attachment_data[1]) && $_attachment_data[1] > 1 ) ? $_attachment_data[1] : $_width;
+              $_height 			= ( isset($_attachment_data[2]) && $_attachment_data[2] > 1 ) ? $_attachment_data[2] : $_height;
           } else { //old treatment
               //rebuild the logo path : check if the full path is already saved in DB. If not, then rebuild it.
               $upload_dir 			= wp_upload_dir();


### PR DESCRIPTION
Looks like that when you upload an svg (or at least the one used here:
https://wordpress.org/support/topic/svg-images-not-working
 )
wp_get_attachment_src(...) may return wrong size values (1,1).

Could just this be a correct fix?