### PR TITLE
Fix: retrieve correct ID in posts page

### DIFF
--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -251,7 +251,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       */
       function tc_get_the_ID()  {
           global $wp_version;
-          if ( version_compare( $wp_version, '3.4.1', '<=' ) )
+          if ( in_the_loop() || version_compare( $wp_version, '3.4.1', '<=' ) )
             {
               $tc_id            = get_the_ID();
             }


### PR DESCRIPTION
see: http://themesandco.com/snippet/display-post-metas-home-page/comment-page-1/#comment-289929
when wp_query->is_posts_page == true, and in the loop, basically get_query_object()->ID returns always the id of the first post.

Still regarding post metas:
https://wordpress.org/support/topic/eliminate-about-at-end-of-each-blog-page
this is about conditional options
I see this function (slightly different though) it's also in some extensions.
Suggestion:
if extensions are running on customizr(-pro) don't add filters already added in the theme.