### PR TITLE
Fix: check if wp_query var exists

### DIFF
--- a/inc/class-fire-init.php
+++ b/inc/class-fire-init.php
@@ -714,7 +714,7 @@ if ( ! class_exists( 'TC_init' ) ) :
           add_action('wp', 'tc_events_calendar_comp', 100);
           function tc_events_calendar_comp(){
             global $wp_query;
-            if ( ! $wp_query -> tribe_is_event_query )
+            if ( ! ( isset($wp_query -> tribe_is_event_query) && $wp_query -> tribe_is_event_query ) )
                 return;
 
             if ( method_exists( 'TC_headings', 'tc_content_heading_title' ) ){


### PR DESCRIPTION
otherwise a notice will be displayed (plug-in not running) when WP_DEBUG=true