### PR TITLE
Fix: force hiding #tc-reset-margin-top when no sticky header

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -547,6 +547,9 @@ h2.comments-title:before {
 #tc-reset-margin-top {
   display: none;
 }
+body:not(.tc-sticky-header) #tc-reset-margin-top {
+  display: none !important;
+}
 /*.tc-sticky-header #tc-reset-margin-top {
   width: 100%;
   display: block;


### PR DESCRIPTION
A possible solution to the following problem:
Sticky header enabled.
I see that opening the mobile menu makes the header not fixed (removing the body class "tc-sticky-header"), but #tc-reset-margin-top is still shown (and its margin valued). This is only tolerable when you have a menu with an height >= of the #tc-reset-margin-top's margin (header's height).