### PR TITLE
Fix: handle mobile menu display in tc_common (tc_custom)

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -772,13 +772,10 @@ h2.site-description {
 }
 
 
-/* Offset the responsive button for proper vertical alignment */
+/* Hide responsive button by default */
 
 .navbar .btn-navbar {
-  margin-top: 7px;
-}
-.navbar-inner .tc-nav-button {
-  display:none;
+  display: none;
 }
 .navbar .btn-navbar:hover, .navbar .btn-navbar:focus, .navbar .btn-navbar:active, .navbar .btn-navbar.active {
   outline: 0;

--- a/inc/assets/less/tc_skin_rules.less
+++ b/inc/assets/less/tc_skin_rules.less
@@ -195,7 +195,6 @@ input[type="checkbox"]:focus {
 // Navbar button for toggling navbar items in responsive layouts
 // These definitions need to come after '.navbar .btn'
 .navbar .btn-navbar {
-  display: none;
   float: right;
   padding: 7px 10px;
   margin-left: 5px;


### PR DESCRIPTION
Removed .navbar .btn-navbar {display: none} from the skin less file, handle it in tc_custom
Should fix the issue which kept the mobile button hidden in mobiles.