### PR TITLE
Fix: force .nav-collapse height to auto when window width > 979px

### DIFF
--- a/inc/assets/less/tc_custom_responsive.less
+++ b/inc/assets/less/tc_custom_responsive.less
@@ -101,6 +101,10 @@
   // .tc-is-mobile .navbar .nav li > ul ul {
   //   display: block;
   // }
+  /* force min .nav-collapse height to auto */
+  .nav-collapse.collapse {
+    height: auto !important;
+  }
 }
 
 @media (max-width: 979px) {


### PR DESCRIPTION
Fixes the following issue:
1) Shrink the page to width <980px
2) Open mobile menu
3) Close mobile menu -> .nav-collapse height set to 0
4) Re-enlarge the window -> .nav-collapse height is still 0, visual issue!

strangely this doesn't happen on the demo site. The "weird" thing is that the demo site .navbar-wrapper doesn't have the class "pull-menu-left"(right), it just has "left" ..