### PR TITLE
Fix: add clear:both to boostrap .nav-collapse

### DIFF
--- a/inc/assets/less/bootstrap/navbar.less
+++ b/inc/assets/less/bootstrap/navbar.less
@@ -41,6 +41,7 @@
 .nav-collapse.collapse {
   height: auto;
   overflow: visible;
+  clear: both;
 }
 
 


### PR DESCRIPTION
fix the misplacing .nav-collapse when no socials are displayed in header