### PR TITLE
Fix: tagline navbar-wrapper.

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -695,12 +695,13 @@ body:not(.tc-sticky-header) #tc-reset-margin-top {
 }
 /* Downsize the brand/project name a bit */
 
-.navbar-wrapper .navbar h2 {
+.navbar-wrapper .navbar .site-description {
   float: right;
   padding-right: 5px;
-  font-style: italic;
-  line-height: 19px;
   text-align: right;
+}
+.navbar-wrapper .navbar h2.site-description {
+  line-height: 19px;
   /* max-width: 240px; */
 }
 /* NO NAVBAR */


### PR DESCRIPTION
Navbar h2 => use .site-description instead of H2 and split the CSS rule in two parts