### PR TITLE
Fix: amend conflicting actions when dropdowntoViewport false

### DIFF
--- a/inc/assets/js/parts/bootstrap.js
+++ b/inc/assets/js/parts/bootstrap.js
@@ -1651,6 +1651,9 @@ var TCParams = TCParams || {};
 
       //@tc adddon
       //give the revealed sub menu the height of the visible viewport
+      if ( ! this.$element.hasClass('nav-collapse') )
+          return;
+
       if ( 1 == TCParams.dropdowntoViewport )
       {
         var tcVisible = $('body').hasClass('sticky-enabled') ? $(window).height() : ($(window).height() - $('.navbar-wrapper').offset().top);


### PR DESCRIPTION
and link to an anchor clicked.
Perform those actions just when clicking on the menu button (responsive mode)

Fixes:
https://wordpress.org/support/topic/accordion-8
and
the issue with the Changelog accordions in TC