### PR TITLE
Fix: smoot scroll compatibility with UPME

### DIFF
--- a/inc/assets/js/parts/main.js
+++ b/inc/assets/js/parts/main.js
@@ -185,7 +185,7 @@ jQuery(function ($) {
     var SmoothScroll = _p.SmoothScroll;
 
     if ('easeOutExpo' == SmoothScroll) {
-        $('a[href^="#"]', '#content').not('[class*=edd], .tc-carousel-control, .carousel-control, [data-toggle="modal"], [data-toggle="dropdown"], [data-toggle="tooltip"], [data-toggle="popover"], [data-toggle="collapse"], [data-toggle="tab"]').click(function () {
+        $('a[href^="#"]', '#content').not('[class*=edd], .tc-carousel-control, .carousel-control, [data-toggle="modal"], [data-toggle="dropdown"], [data-toggle="tooltip"], [data-toggle="popover"], [data-toggle="collapse"], [data-toggle="tab"]', '[class*=upme]').click(function () {
             var anchor_id = $(this).attr("href");
             if ('#' != anchor_id) {
                 $('html, body').animate({


### PR DESCRIPTION
User Profiles Made Easy compatibility.
When clicking on a button like <a href="#edit" class="upme-button-alt upme-fire-editor">View Profile</a>
"Uncaught TypeError: Cannot read property 'top' of undefined" was thrown
ref: http://themesandco.com/support-forums/topic/customizr-theme-js-some-plugins-not-working-with-this-theme/#post-57993