### PR TITLE
Fix: do not display resp menu button when sticky enabled and tc-menu-off

### DIFF
--- a/inc/assets/less/tc_custom_responsive.less
+++ b/inc/assets/less/tc_custom_responsive.less
@@ -371,6 +371,10 @@
     position: relative;
     z-index: 1;
   }
+  /* do not display menu button when sticky enabled and tc-menu-off enabled */
+  .sticky-enabled .tc-menu-off .btn-navbar {
+    display: none;
+  }
 
   .no-navbar .nav-collapse, .nav-collapse.collapse {
     /* default fallback */


### PR DESCRIPTION
fixes: https://wordpress.org/support/topic/responsive-nav-menu-behavior-broken?replies=2#post-6642813