### PR TITLE
Fix: some minor changes to avoid weird behavior when loading page

### DIFF
--- a/inc/assets/js/parts/main.js
+++ b/inc/assets/js/parts/main.js
@@ -540,9 +540,10 @@ jQuery(function ($) {
         _set_header_top_offset();
         //process scrolling actions
         if ( $(window).scrollTop() > triggerHeight ) {
-            $('body').addClass("sticky-enabled").removeClass("sticky-disabled");
+            if ( $('body').hasClass('sticky-disabled') )
+                $('body').addClass("sticky-enabled").removeClass("sticky-disabled");
         }
-        else {
+        else if ( $('body').hasClass('sticky-enabled') ){
             $('body').removeClass("sticky-enabled").addClass("sticky-disabled");
             setTimeout( function() { _refresh();} ,
               $('body').hasClass('is-customizing') ? 100 : 20

--- a/inc/assets/js/parts/main.js
+++ b/inc/assets/js/parts/main.js
@@ -510,7 +510,7 @@ jQuery(function ($) {
 
     //LOADING ACTIONS
     if ( _is_sticky_enabled() )
-        setTimeout( function() { _refresh(); } , 20 );
+        setTimeout( function() { _set_sticky_offsets(); _scrolling_actions(); } , 20 );
 
     //RESIZING ACTIONS
     $(window).resize(function() {

--- a/inc/assets/js/parts/main.js
+++ b/inc/assets/js/parts/main.js
@@ -500,7 +500,7 @@ jQuery(function ($) {
             logosH[$i]  = $(this).attr('height');
 
             //check that all numbers are valid before using division
-            if ( 0 === _.size( _.filter( [ logosW[$i], logosH[$i] ], function(num){ return _.isNumber(num) && 0 !== num; } ) ) )
+            if ( 0 === _.size( _.filter( [ logosW[$i], logosH[$i] ], function(num){ num = parseInt(num); return _.isNumber(num) && 0 !== num; } ) ) )
               return;
 
             logosRatio[$i]  = logosW[$i] / logosH[$i];
@@ -510,7 +510,7 @@ jQuery(function ($) {
 
     //LOADING ACTIONS
     if ( _is_sticky_enabled() )
-        setTimeout( function() { _set_sticky_offsets(); _scrolling_actions(); } , 20 );
+        setTimeout( function() { _refresh(); _scrolling_actions(); } , 20 );
 
     //RESIZING ACTIONS
     $(window).resize(function() {

--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -544,6 +544,12 @@ body:not(.tc-sticky-header) #tc-reset-margin-top {
     -o-transition: all 0.15s;
     transition: all 0.15s;
 }
+.tc-sticky-header #tc-reset-margin-top{
+  display: block;
+}
+.sticky-disabled .tc-header {
+  top: 0;
+}
 .sticky-enabled .tc-header {
   height: auto!important;
   /* default fallback */


### PR DESCRIPTION
and sticky header set, also fix logos dimension not set (_.isNumber(num) returned false on width and height attr values => pretty important! )

on page loading:
a) CSS: set top: 0 when sticky disabled in CSS, it will changed in js if needed (see admin bar)
b) CSS: make tc-margin-top always visible for tc-sticky-header body class, this will reduce the jumping of the content while loading the page (before js takes effect)
c) JS: in LOADING ACTIONS call also  _scrolling_actions(). This because sometimes when you refresh (browser) an already scrolled page (or go to an anchor in a different page), for some reason (at least with chrome) the scroll event isn't fired => the header stays with its original size.
