### PR TITLE
Fix: first step, load rtl css also if WP_LANG not defined

### DIFF
--- a/inc/class-fire-init.php
+++ b/inc/class-fire-init.php
@@ -546,11 +546,11 @@ if ( ! class_exists( 'TC_init' ) ) :
         //Finds the good path : are we in a child theme and is there a skin to override?
         $remote_path    = ( TC___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/' : false ;
         $remote_path    = ( ! $remote_path && file_exists(TC_BASE .'inc/assets/css/' . $_sheet) ) ? TC_BASE_URL .'inc/assets/css/' : $remote_path ;
-
         //Checks if there is a rtl version of common if needed
-        if ( 'skin' != $_wot && defined( 'WPLANG' ) && ( 'ar' == WPLANG || 'he_IL' == WPLANG ) ) {
-          $remote_path   = ( TC___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/rtl/' : $remote_path ;
-          $remote_path   = ( !TC___::$instance -> tc_is_child() && file_exists(TC_BASE .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL .'inc/assets/css/rtl/' : $remote_path ;
+        if ( 'skin' != $_wot && ( is_rtl() || ( defined( 'WPLANG' ) && ( 'ar' == WPLANG || 'he_IL' == WPLANG ) ) ) ){
+          $remote_rtl_path   = ( TC___::$instance -> tc_is_child() && file_exists(TC_BASE_CHILD .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL_CHILD .'inc/assets/css/rtl/' : false ;
+          $remote_rtl_path   = ( ! $remote_rtl_path && file_exists(TC_BASE .'inc/assets/css/rtl/' . $_sheet) ) ? TC_BASE_URL .'inc/assets/css/rtl/' : $remote_rtl_path;
+          $remote_path       = $remote_rtl_path ? $remote_rtl_path : $remote_path;
         }
 
         //Defines the active skin and fallback to blue.css if needed


### PR DESCRIPTION
but is_rtl() and load the parent rtl css even if we use a child without our rtl css version.

More a reminder than a real PR. is_rtl() could totally replace the check on WP_LANG, but I'm not sure about wp backward compatibility that's why I kept both.
Also those checks could be done "better" using an actual if-else statement instead of the ternary operator, but I kept your structure, since you really love it :P 
There are others things to the relatively to the css, but at the moment couldn't figure out how do you generate the rtl tc_common.css . Any clue? :D