### PR TITLE
Fix: comment-reply use default add-below param

### DIFF
--- a/inc/parts/class-content-comments.php
+++ b/inc/parts/class-content-comments.php
@@ -169,7 +169,7 @@ if ( ! class_exists( 'TC_comments' ) ) :
                                                                         array(  'reply_text' => __( 'Reply' , 'customizr' ).' <span>&darr;</span>',
                                                                                 'depth' => $depth,
                                                                                 'max_depth' => $args['max_depth'] ,
-                                                                                'add_below' => apply_filters( 'tc_comment_reply_below' , 'li-comment' )
+                                                                                'add_below' => apply_filters( 'tc_comment_reply_below' , 'comment' )
                                                                               )
                                                                   )
                                             )


### PR DESCRIPTION
Look that this is the default wordpress add-below param. So you can either totally remove the add-below param, but since there's a filter I decided to leave it.

This works here, though in TC it doesn't. This 'cause the <article> comment in TC doesn't have the id attribute like id="comment-N", why?