### PR TITLE
Fix: hook post-metas and headings early actions to wp_head instead of wp

### DIFF
--- a/inc/parts/class-content-headings.php
+++ b/inc/parts/class-content-headings.php
@@ -17,11 +17,11 @@ if ( ! class_exists( 'TC_headings' ) ) :
       function __construct () {
         self::$instance =& $this;
         //set actions and filters for posts and page headings
-        add_action( 'wp_head'                            , array( $this , 'tc_set_post_page_heading_hooks') );
+        add_action( 'template_redirect'                            , array( $this , 'tc_set_post_page_heading_hooks') );
         //set actions and filters for archives headings
-        add_action( 'wp_head'                            , array( $this , 'tc_set_archives_heading_hooks') );
+        add_action( 'template_redirect'                            , array( $this , 'tc_set_archives_heading_hooks') );
         //Set headings user options
-        add_action( 'wp_head'                            , array( $this , 'tc_set_headings_options') );
+        add_action( 'template_redirect'                            , array( $this , 'tc_set_headings_options') );
       }
 
 

--- a/inc/parts/class-content-headings.php
+++ b/inc/parts/class-content-headings.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'TC_headings' ) ) :
       /**
       * @return void
       * set up hooks for archives headings
-      * callback of wp
+      * callback of template_redirect
       *
       * @package Customizr
       * @since Customizr 3.2.6
@@ -60,7 +60,7 @@ if ( ! class_exists( 'TC_headings' ) ) :
       /**
       * @return void
       * set up hooks for post and page headings
-      * callback of wp
+      * callback of template_redirect
       *
       * @package Customizr
       * @since Customizr 3.2.6
@@ -411,7 +411,7 @@ if ( ! class_exists( 'TC_headings' ) ) :
       /**
       * @return void
       * set up user defined options
-      * callback of wp
+      * callback of template_redirect
       *
       * @package Customizr
       * @since Customizr 3.2.6

--- a/inc/parts/class-content-headings.php
+++ b/inc/parts/class-content-headings.php
@@ -17,11 +17,11 @@ if ( ! class_exists( 'TC_headings' ) ) :
       function __construct () {
         self::$instance =& $this;
         //set actions and filters for posts and page headings
-        add_action( 'wp'                            , array( $this , 'tc_set_post_page_heading_hooks') );
+        add_action( 'wp_head'                            , array( $this , 'tc_set_post_page_heading_hooks') );
         //set actions and filters for archives headings
-        add_action( 'wp'                            , array( $this , 'tc_set_archives_heading_hooks') );
+        add_action( 'wp_head'                            , array( $this , 'tc_set_archives_heading_hooks') );
         //Set headings user options
-        add_action( 'wp'                            , array( $this , 'tc_set_headings_options') );
+        add_action( 'wp_head'                            , array( $this , 'tc_set_headings_options') );
       }
 
 

--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -17,9 +17,9 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         function __construct () {
           self::$instance =& $this;
           //Show / hide metas based on customizer user options (@since 3.2.0)
-          add_action( 'wp'                            , array( $this , 'tc_set_visibility_options' ) , 10 );
+          add_action( 'wp_head'                            , array( $this , 'tc_set_visibility_options' ) , 10 );
            //Show / hide metas based on customizer user options (@since 3.2.0)
-          add_action( 'wp'                            , array( $this , 'tc_set_design_options' ) , 20 );
+          add_action( 'wp_head'                            , array( $this , 'tc_set_design_options' ) , 20 );
           //Show / hide metas based on customizer user options (@since 3.2.0)
           add_action( '__after_content_title'         , array( $this , 'tc_set_post_metas_hooks' ), 20 );
 

--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -32,7 +32,7 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         /**
         * Set the post metas visibility based on Customizer options
         * uses hooks tc_show_post_metas, body_class
-        * hook : wp
+        * hook : template_redirect
         *
         * @package Customizr
         * @since Customizr 3.2.0
@@ -84,7 +84,7 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
 
         /**
         * Default metas visibility controller
-        * tc_show_post_metas gets filtered by tc_set_visibility_options() called early in wp
+        * tc_show_post_metas gets filtered by tc_set_visibility_options() called early in template_redirect
         * @return  boolean
         * @package Customizr
         * @since Customizr 3.2.6

--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -17,9 +17,9 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         function __construct () {
           self::$instance =& $this;
           //Show / hide metas based on customizer user options (@since 3.2.0)
-          add_action( 'wp_head'                            , array( $this , 'tc_set_visibility_options' ) , 10 );
+          add_action( 'template_redirect'                            , array( $this , 'tc_set_visibility_options' ) , 10 );
            //Show / hide metas based on customizer user options (@since 3.2.0)
-          add_action( 'wp_head'                            , array( $this , 'tc_set_design_options' ) , 20 );
+          add_action( 'template_redirect'                            , array( $this , 'tc_set_design_options' ) , 20 );
           //Show / hide metas based on customizer user options (@since 3.2.0)
           add_action( '__after_content_title'         , array( $this , 'tc_set_post_metas_hooks' ), 20 );
 


### PR DESCRIPTION
Could you please include also this small pull-request?
As I told you I was digging into displaying a static front page with pagination (template with a custom loop) and found that some of those actions hooked to wp, for some reason, reset the query var 'page', which is needed in those cases (https://codex.wordpress.org/Pagination#static_front_page) . I've found that the problem happened (for example, in headings) here: https://github.com/Nikeo/customizr/blob/master/inc/parts/class-content-headings.php#L71 (when hooked to wp). Basically the <pre>is_front_page()</pre> caused that. I cannot understand the reason though.
So not all those methods should be re-hooked to wp_head to avoid this, just the ones which refers to is_front_page(), tc__f('__is_home') and so on.
I think there's nothing wrong with that, right? I mean, no side effects..
I also hope this can fix the issue with some plugins showing custom loops in static home front page (see edd).
For sure it fixes the issue with my template ;)
But if you have any doubt  well I don't get offended :package: 

Good night ;)