### PR TITLE
Fix: avoid plugin's conflicts with the centering slides feature:

### DIFF
--- a/inc/assets/js/parts/bootstrap.js
+++ b/inc/assets/js/parts/bootstrap.js
@@ -1870,7 +1870,7 @@ var TCParams = TCParams || {};
     }
 
   , slide: function (type, next) {
-      if(!$.support.transition && this.$element.hasClass('slide')) {
+      if(!$.support.transition && this.$element.hasClass('customizr-slide')) {
          this.$element.find('.item').stop(true, true); //Finish animation and jump to end.
       }
       var $active = this.$element.find('.item.active')
@@ -1902,7 +1902,7 @@ var TCParams = TCParams || {};
         })
       }
 
-      if ($.support.transition && this.$element.hasClass('slide')) {
+      if ($.support.transition && this.$element.hasClass('customizr-slide')) {
         this.$element.trigger(e)
         if (e.isDefaultPrevented()) return
         //tc addon => trigger slide event to img
@@ -1923,7 +1923,7 @@ var TCParams = TCParams || {};
               $next.find('img').trigger('slid');
           }, 0)
         })
-      } else if(!$.support.transition && this.$element.hasClass('slide')) {
+      } else if(!$.support.transition && this.$element.hasClass('customizr-slide')) {
           this.$element.trigger(e)
           if (e.isDefaultPrevented()) return
           $active.animate({left: (direction == 'right' ? '100%' : '-100%')}, 600, function(){

--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -207,7 +207,7 @@ class TC_slider {
     $layout_value                 = apply_filters( 'tc_slider_layout', $layout_value, $queried_id );
 
     //declares the layout vars
-    $layout_class                 = implode( " " , apply_filters( 'tc_slider_layout_class' , ( 0 == $layout_value ) ? array('container', 'carousel', 'slide') : array('carousel', 'slide') ) );
+    $layout_class                 = implode( " " , apply_filters( 'tc_slider_layout_class' , ( 0 == $layout_value ) ? array('container', 'carousel', 'customizr-slide') : array('carousel', 'customizr-slide') ) );
     $img_size                     = apply_filters( 'tc_slider_img_size' , ( 0 == $layout_value ) ? 'slider' : 'slider-full');
 
     //get slides


### PR DESCRIPTION
replace the #customizr-slider's 'slide' class with 'customizr-slide'

Alternatively we can parametrize it (tcparams)
or yell at some developers :P