### PR TITLE
Fix: fix logo ratio, apply only when no sticky-logo set

### DIFF
--- a/inc/assets/js/parts/main.js
+++ b/inc/assets/js/parts/main.js
@@ -459,7 +459,7 @@ jQuery(function ($) {
           isCustomizing   = $('body').hasClass('is-customizing'),
           customOffset    = +_p.stickyCustomOffset,
           $sticky_logo    = $('img.sticky', '.site-logo'),
-          logo            = 0 == $sticky_logo.length ? { _logo: $('img:not(".sticky")', '.site-logo') , _ratio: '' }: false;
+          logo            = 0 === $sticky_logo.length ? { _logo: $('img:not(".sticky")', '.site-logo') , _ratio: '' }: false;
 
     function _is_scrolling() {
         return $('body').hasClass('sticky-enabled') ? true : false;

--- a/inc/assets/js/parts/main.js
+++ b/inc/assets/js/parts/main.js
@@ -458,9 +458,8 @@ jQuery(function ($) {
           isUserLogged    = $('body').hasClass('logged-in') || 0 !== $('#wpadminbar').length,
           isCustomizing   = $('body').hasClass('is-customizing'),
           customOffset    = +_p.stickyCustomOffset,
-          logosH     = [],
-          logosW      = [],
-          logosRatio      = [];
+          $sticky_logo    = $('img.sticky', '.site-logo'),
+          logo            = 0 == $sticky_logo.length ? { _logo: $('img:not(".sticky")', '.site-logo') , _ratio: '' }: false;
 
     function _is_scrolling() {
         return $('body').hasClass('sticky-enabled') ? true : false;
@@ -505,14 +504,11 @@ jQuery(function ($) {
 
 
     function _set_logo_height(){
-        if ( 0 === $('img' , '.site-logo').length )
+        if ( logo && 0 === logo._logo.length || ! logo._ratio )
             return;
-        $.each($('img', '.site-logo'), function( $i ){
-            if ( ! logosRatio[$i] )
-              return;
-            var logoHeight   = $(this).width() / logosRatio[$i];
-            $(this).css('height' , logoHeight );
-        });
+        
+        logo._logo.css('height' , logo._logo.width() / logo._ratio );
+        
         setTimeout( function() {
             _set_sticky_offsets();
             _set_header_top_offset();
@@ -522,18 +518,16 @@ jQuery(function ($) {
 
     //set site logo width and height if exists
     //=> allow the CSS3 transition to be enabled
-    if ( _is_sticky_enabled() && 0 !== $('img' , '.site-logo').length ) {
-        $.each($('img', '.site-logo'), function( $i ){
-            logosW[$i]  = $(this).attr('width');
-            logosH[$i]  = $(this).attr('height');
+    if ( _is_sticky_enabled() && logo && 0 !== logo._logo.length ) {
+        var logoW = logo._logo.attr('width'),
+            logoH = logo._logo.attr('height');
 
-            //check that all numbers are valid before using division
-            if ( 0 === _.size( _.filter( [ logosW[$i], logosH[$i] ], function(num){ return _.isNumber( parseInt(num, 10) ) && 0 !== num; } ) ) )
-              return;
+        //check that all numbers are valid before using division
+        if ( 0 === _.size( _.filter( [ logoW, logoH ], function(num){ return _.isNumber( parseInt(num, 10) ) && 0 !== num; } ) ) )
+          return;
 
-            logosRatio[$i]  = logosW[$i] / logosH[$i];
-            $(this).css('height' , logosH[$i]  ).css('width' , logosW[$i] );
-        });
+        logo._ratio  = logoW / logoH;
+        logo._logo.css('height' , logoH  ).css('width' , logoW );
     }
 
     //LOADING ACTIONS
@@ -570,7 +564,7 @@ jQuery(function ($) {
         if ( $(window).scrollTop() > triggerHeight ) {
             $('body').addClass("sticky-enabled").removeClass("sticky-disabled");
         }
-        else if ( $('body').hasClass('sticky-enabled') ) {
+        else if ( _is_scrolling() ) {
             $('body').removeClass("sticky-enabled").addClass("sticky-disabled");
             setTimeout( function() { _sticky_refresh();} ,
               $('body').hasClass('is-customizing') ? 100 : 20


### PR DESCRIPTION
Hi Nico,
pretty important 'cause the sticky-logo ratio was totally wrong ( I know it was one of my ideas :D).
With this fix we set the width/height just to the main logo, and just when no sticky-logo is set ('cause when there's a sticky-logo we don't need transitions).

Cheers