### PR TITLE
Fix: fix case when .round-div.no-effect had a misplaced link

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -1273,7 +1273,7 @@ footer#footer .colophon .social-block a {
 }
 
 .round-div.no-effect {
-  border:none;
+  border-color: transparent;
 }
 #footer .round-div {
   border-color:@FooterBg;

--- a/inc/parts/class-content-post_thumbnails.php
+++ b/inc/parts/class-content-post_thumbnails.php
@@ -225,11 +225,11 @@ class TC_post_thumbnails {
 
       //handles the case when the image dimensions are too small
       $thumb_size       = apply_filters( 'tc_thumb_size' , TC_init::$instance -> tc_thumb_size, TC_utils::tc_id()  );
-      $no_effect_class  = ( isset($tc_thumb) && isset($tc_thumb_height) && ( $tc_thumb_height < $thumb_size['width']) ) ? 'no-effect' : '';
+      $no_effect_class  = ( isset($tc_thumb) && isset($tc_thumb_height) && ( $tc_thumb_height < $thumb_size['height']) ) ? 'no-effect' : '';
       $no_effect_class  = ( ! isset($tc_thumb) || empty($tc_thumb_height) || empty($tc_thumb_width) ) ? '' : $no_effect_class;
 
       //default hover effect
-      $thumb_wrapper    = sprintf('<div class="%5$s %1$s"><div class="round-div"></div><a class="round-div %1$s" href="%2$s" title="%3$s"></a>%4$s</div>',
+      $thumb_wrapper    = sprintf('<div class="%5$s %1$s"><div class="round-div %1$s"></div><a class="round-div %1$s" href="%2$s" title="%3$s"></a>%4$s</div>',
                                     implode( " ", apply_filters( 'tc_thumbnail_link_class', array( $no_effect_class ) ) ),
                                     get_permalink( get_the_ID() ),
                                     esc_attr( strip_tags( get_the_title( get_the_ID() ) ) ),

--- a/inc/parts/class-content-post_thumbnails.php
+++ b/inc/parts/class-content-post_thumbnails.php
@@ -227,6 +227,7 @@ class TC_post_thumbnails {
       $thumb_size       = apply_filters( 'tc_thumb_size' , TC_init::$instance -> tc_thumb_size, TC_utils::tc_id()  );
       $no_effect_class  = ( isset($tc_thumb) && isset($tc_thumb_height) && ( $tc_thumb_height < $thumb_size['height']) ) ? 'no-effect' : '';
       $no_effect_class  = ( ! isset($tc_thumb) || empty($tc_thumb_height) || empty($tc_thumb_width) ) ? '' : $no_effect_class;
+      $no_effect_class  = esc_attr( TC_utils::$inst->tc_opt( 'tc_center_img') ) ? '' : $no_effect_class;
 
       //default hover effect
       $thumb_wrapper    = sprintf('<div class="%5$s %1$s"><div class="round-div %1$s"></div><a class="round-div %1$s" href="%2$s" title="%3$s"></a>%4$s</div>',


### PR DESCRIPTION
Not really sure why we have a div and <a> both with round-div class. But anyway, this patch will fix the a href misplacement when no-effect. Using border-color transparent (or none) instead of border none will ensure the a round-div is still well placed.
Is this what you wanted? round-div with no-effect (because of the image size too small) should display no "mask" right?
Alternatively, if isn't what you wanted, we have to remove the 'no-effect' class to the <a> and use .round-div.no-effect a {border-color: transparent;} (removing .round-div.no-effect {border-none;}) This way we have the correct link placement and keep the expansion.

p.s.
the no-effect class should not be added when centering images is enabled. see last commit, though I think a normal if else statement will be better ;)
