### PR TITLE
Fix: override bootstrap thumbnails left margin for woocommerce ones

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -2084,6 +2084,10 @@ img.v-centered {
   background: none;
   background: none;
 }
+/* Woocommerce thumbnails */
+.woocommerce .thumbnails {
+  margin-left: 0;
+}
 
 /* WP CSS
     -------------------------------------------------- */


### PR DESCRIPTION
You can see the thumbnail negative margin issue.
http://demo.presscustomizr.com/product/happy-ninja/

This should fix it