### PR TITLE
Fix: reset navbar-inner padding-right when logo centered

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -650,6 +650,10 @@ body:not(.tc-sticky-header) #tc-reset-margin-top {
 .tc-no-sticky-header .logo-centered .brand, .sticky-disabled .logo-centered .brand {
   width: 100%;
 }
+.tc-no-sticky-header .logo-centered .navbar-inner, .sticky-disabled .logo-centered .navbar-inner {
+  padding-right: 5px;
+}
+
 .tc-header .outside {
   display:none;
 }


### PR DESCRIPTION
A navbar-inner padding-right of 20px when padding-left is 5px and logo/menu are centered, I think doesn't make that sense.. :D