### PR TITLE
Fix: don't load unnecessary classes when in wordpress Customize

### DIFF
--- a/inc/init-pro.php
+++ b/inc/init-pro.php
@@ -30,8 +30,8 @@ if ( ! class_exists( 'TC_init_pro' ) ) :
 
             //loads and instanciates the activation / updates classes
             foreach ( $_classes as $name => $params ) {
-                //don't load activation classes if not admin
-                if ( ! is_admin() && false !== strpos($params[0], 'activation-key') )
+                //don't load activation classes if not admin or in customize
+                if ( ( TC___::$instance -> is_customizing || ! is_admin() ) && false !== strpos($params[0], 'activation-key') )
                   continue;
 
                 $_file_path =  dirname( dirname( __FILE__ ) ) . $params[0];

--- a/inc/init.php
+++ b/inc/init.php
@@ -65,6 +65,9 @@ if ( ! class_exists( 'TC___' ) ) :
 
             self::$theme_name                 = sanitize_file_name( strtolower($tc_base_data['title']) );
 
+            //checks if is customizing : two context, admin and front (preview frame)
+            $this -> is_customizing = $this -> tc_is_customizing();
+
             //CUSTOMIZR_VER is the Version
             if( ! defined( 'CUSTOMIZR_VER' ) )      define( 'CUSTOMIZR_VER' , $tc_base_data['version'] );
             //TC_BASE is the root server path of the parent theme
@@ -153,8 +156,9 @@ if ( ! class_exists( 'TC___' ) ) :
             foreach ( $load as $group => $files ) {
                 foreach ($files as $path_suffix ) {
 
-                    //don't load admin classes if not admin && not customizing
-                    if ( is_admin() && ! $this -> is_customizing ) {
+                    // don't load admin classes if not admin && not customizing
+                    // load front-end classes in admin
+                    if ( is_admin() ) {
                         if ( false !== strpos($path_suffix[0], 'parts') )
                             continue;
                     }


### PR DESCRIPTION
Front classes don't need to be loaded when in customize left panel (is_admin() === true)
Same thing for pro activation classes.

I think is fine, but double check, your competence in the customize land is far better than mine, though I'm better with women .. I know :P