### PR TITLE
Fix: fix issue with contents containing many many links

### DIFF
--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -430,7 +430,8 @@ if ( ! class_exists( 'TC_utils' ) ) :
 
         $pattern ="/<a(.*?)href=( '|\")(.*?).(bmp|gif|jpeg|jpg|png)( '|\")(.*?)>/i";
         $replacement = '<a$1href=$2$3.$4$5 class="grouped_elements" rel="tc-fancybox-group'.$post -> ID.'"$6>';
-        $content = preg_replace( $pattern, $replacement, $content);
+        $r_content = preg_replace( $pattern, $replacement, $content);
+        $content = $r_content ? $r_content : $content;
         return apply_filters( 'tc_fancybox_content_filter', $content );
       }
 


### PR DESCRIPTION
Ok this is kinda hack.
Reported here: http://presscustomizr.com/support-forums/topic/maximum-number-of-hyperlinks-in-a-page/#post-68165

Looks like that with a long list of links in the content that preg_replace returns an empty string, dunno why, haven't investigated on it. Maybe we can use a better pattern/replacement? Dunno, is about some memory leak? Dunno .. but probably the latter.

Anyway this just prevents the returning of an empty string.