### PR TITLE
Fix: disabling global tc_post_metas didn't hide metas

### DIFF
--- a/inc/admin/js/theme-customizer-preview.js
+++ b/inc/admin/js/theme-customizer-preview.js
@@ -178,25 +178,20 @@
 	//Post metas
 	wp.customize( 'tc_theme_options[tc_show_post_metas]' , function( value ) {
 		value.bind( function( to ) {
-			if ( false === to ) {
+			if ( false === to )
 				$('.entry-header .entry-meta' , '.article-container').hide('slow');
-
-			}
-			else if (! $('body').hasClass('hide-post-metas') ) {
+            else if (! $('body').hasClass('hide-post-metas') ){
 				$('.entry-header .entry-meta' , '.article-container').show('fast');
-			}
+                $('body').removeClass('hide-all-post-metas');
+            }
 		} );
 	} );
 	wp.customize( 'tc_theme_options[tc_show_post_metas_home]' , function( value ) {
 		value.bind( function( to ) {
-			if ( false === to ) {
+			if ( false === to )
 				$('.entry-header .entry-meta' , '.home .article-container').hide('slow');
-				$('body').addClass('hide-post-metas');
-			}
-			else {
-				$('body').removeClass('hide-post-metas');
+			else
 				$('.entry-header .entry-meta' , '.home .article-container').show('fast');
-			}
 		} );
 	});
 	wp.customize( 'tc_theme_options[tc_show_post_metas_single_post]' , function( value ) {

--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -1658,6 +1658,7 @@ embed, iframe, object, video {
 max-width: 100%;
 }
 
+.hide-all-post-metas .entry-header .entry-meta,
 .hide-post-metas .entry-header .entry-meta {
   display: none;
 }

--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -39,6 +39,14 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
         */
         function tc_set_visibility_options() {
           //if customizing context, always render. Will be hidden in the DOM with a body class filter is disabled.
+          if ( 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas' ) ) ) {
+            if ( TC___::$instance -> tc_is_customizing() )
+              add_filter( 'body_class' , array( $this , 'tc_hide_all_post_metas') );
+            else{
+              add_filter( 'tc_show_post_metas' , '__return_false' );
+              return;
+            }
+          }
           if ( is_singular() && ! is_page() && ! tc__f('__is_home') ) {
               if ( 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas_single_post' ) ) ) {
                   add_filter( 'tc_show_post_metas' , '__return_true' );
@@ -51,7 +59,7 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
               }
               else
                   add_filter( 'tc_show_post_metas' , '__return_false' );
-
+              return;
           }
           if ( ! is_singular() && ! tc__f('__is_home') && ! is_page() ) {
               if ( 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas_post_lists' ) ) ) {
@@ -59,12 +67,13 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
                   return;
               }
 
-                  if ( TC___::$instance -> tc_is_customizing() ) {
-                      add_filter( 'body_class' , array( $this , 'tc_hide_post_metas') );
-                      add_filter( 'tc_show_post_metas' , '__return_true' );
-                  }
-                  else
-                      add_filter( 'tc_show_post_metas' , '__return_false' );
+              if ( TC___::$instance -> tc_is_customizing() ) {
+                  add_filter( 'body_class' , array( $this , 'tc_hide_post_metas') );
+                  add_filter( 'tc_show_post_metas' , '__return_true' );
+              }
+              else
+                  add_filter( 'tc_show_post_metas' , '__return_false' );
+              return;
           }
           if ( tc__f('__is_home') ) {
               if ( 0 != esc_attr( TC_utils::$inst->tc_opt( 'tc_show_post_metas_home' ) ) ) {
@@ -478,6 +487,18 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
           return $_metas_html;
         }
 
+
+
+
+        /**
+        * hook body_class filter
+        *
+        * @package Customizr
+        * @since Customizr 3.2.0
+        */
+        function tc_hide_all_post_metas( $_classes ) {
+          return array_merge($_classes , array('hide-all-post-metas') );
+        }
 
 
         /**


### PR DESCRIPTION
When you disabled "Display post metas" in Customize, metas were hidden in the preview but this had no real effect in the live site.
This should fix that, also should better handle the Customize preview.
(hopefully I am not that sick .. so double/triple check this ;) )

p.s.
reported in the pro forum