### PR TITLE
Fix: disable fade hover links for first level menu items in ie

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -60,6 +60,10 @@ body {
   -o-transition: background-position .1s linear;
   transition: background-position .1s linear;
 }
+/* IE fix for navbar first level items */
+.ie.tc-fade-hover-links .nav > li > a {
+  transition: none !important;
+}
 
 /* External Links style */
 a + span.tc-external:after {


### PR DESCRIPTION
I was able to reproduce the issue with ie11 and the demo site, on which I modeled the fix (with inspect element live) but wasn't able to reproduce it on my local installation, so this requires a double check.
The fix is extended on all ie versions, really couldn't test them all :D 
Still confused about why this happens just with those specific links.. mah
https://wordpress.org/support/topic/navigation-hover-does-not-work-in-ie11?replies=1
( though the css there was buggy :D)