### PR TITLE
Add: comment anchor link

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -1523,6 +1523,9 @@ article .author-info h2 , .archive-header .author-info h2 {
 
 #respond #comment {
   width: 100%;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 .comments-link {
   display: inline-block;
@@ -2242,6 +2245,20 @@ ul.children {
   padding: 0.142857143rem 0.357142857rem;
   font-size: 10px;
   font-size: 0.714285714rem;
+}
+.tc-comment-anchor {
+  float: right;
+  display: block;
+}
+.tc-comment-anchor:hover {
+  text-decoration: none;
+}
+.tc-comment-anchor:before {
+  content: '\1F517';
+  font-family: entypo;
+  position: relative;
+  font-size: 3.5em;
+  top: 0.05em;
 }
 /* Images */
 

--- a/inc/parts/class-content-comments.php
+++ b/inc/parts/class-content-comments.php
@@ -168,12 +168,19 @@ if ( ! class_exists( 'TC_comments' ) ) :
               //gets the comment text => filter parameter!
               $comment_text = get_comment_text( $comment->comment_ID , $args );
 
-              printf('<article id="comment-%9$s" class="comment"><div class="%1$s"><div class="%2$s">%3$s</div><div class="%4$s">%5$s %6$s %7$s %8$s</div></div></article>',
+              //gets the comment link
+              $comment_link = esc_url( get_comment_link( $comment->comment_ID ) );
+
+              printf('<article id="comment-%10$s" class="comment"><div class="%1$s"><div class="%2$s">%3$s</div><div class="%4$s">%5$s %6$s %7$s %8$s %9$s</div></div></article>',
                   apply_filters( 'tc_comment_wrapper_class', 'row-fluid' ),
                   apply_filters( 'tc_comment_avatar_class', 'comment-avatar span2' ),
                   get_avatar( $comment, apply_filters( 'tc_comment_avatar_size', 80 ) ),
                   apply_filters( 'tc_comment_content_class', 'span10' ),
-
+                  apply_filters( 'tc_show_comment_anchor', true) ? sprintf('<a class="%1$s" href="%2$s"></a>',
+                                                                   apply_filters( 'tc_comment_anchor_class',  'tc-comment-anchor' ),
+                                                                   $comment_link
+                                                                    
+                  ) : '',
                   $tc_show_comment_content ? sprintf('<div class="%1$s">%2$s</div>',
                                             apply_filters( 'tc_comment_reply_btn_class', 'reply btn btn-small' ),
                                             get_comment_reply_link( array_merge(
@@ -195,7 +202,7 @@ if ( ! class_exists( 'TC_comments' ) ) :
                             current_user_can( 'edit_comment', $comment->comment_ID ) ? '<p class="edit-link btn btn-success btn-mini"><a class="comment-edit-link" href="' . get_edit_comment_link( $comment->comment_ID ) . '">' . __( 'Edit' , 'customizr' ) . '</a></p>' : ''
                         ),
                         sprintf( '<a class="comment-date" href="%1$s"><time datetime="%2$s">%3$s</time></a>' ,
-                            esc_url( get_comment_link( $comment->comment_ID ) ),
+                            $comment_link,
                             get_comment_time( 'c' ),
                             /* translators: 1: date, 2: time */
                             sprintf( __( '%1$s at %2$s' , 'customizr' ), get_comment_date(), get_comment_time() )


### PR DESCRIPTION
Basic comment anchor link.
The whole comment displaying is probably a little messy :D 
I used sizes expressed in "em", according with the other "icons":before

The "real" problem is that the smooth scroll doesn't work of course, because the href doesn't start with "#".. My idea is that handle this at this stage is pretty useless, we can handle it in the new smooth scroll.
Do you agree?

p-r info:
might conflict with #146 (both affects tc_custom.less)
against v3.3.21 build v5

p.s.
bonus, comment's text-area as border-box. Width 100% + padding made it overflow the window in smaller viewports.
Probably we should make all the text-areas / input text, this way (?)
