### PR TITLE
Fix: don't print private taxonomies, with fix for old php versions

### DIFF
--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -392,8 +392,13 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
 
           //filter the post taxonomies
           while ( $el = current($tax_list) ) {
+              // cast $el stdClass object in an array to access its property 'public'
+              // fix for PHP version < 5.3 (?)
+              $_el = (array) $el;
+
               //skip the post format taxinomy
-              if ( in_array( key($tax_list) , apply_filters_ref_array ( 'tc_exclude_taxonomies_from_metas' , array( array('post_format') , $post_type , TC_utils::tc_id() ) ) ) ) {
+              if ( in_array( key($tax_list) , apply_filters_ref_array ( 'tc_exclude_taxonomies_from_metas' , array( array('post_format') , $post_type , TC_utils::tc_id() ) ) )  || 
+                 ( false === (bool) $_el['public'] && apply_filters_ref_array( 'tc_exclude_private_taxonomies', array( true, $_el['public'], TC_utils::tc_id() ) ) ) ){
                   next($tax_list);
                   continue;
               }


### PR DESCRIPTION
Problem:
looks like in old php versions (< 5.3) we cannot access the property "public" of that object. I feel 'cause it ( "public") is somewhat "reserved", as it doesn't happen with the property "hierarchical"

Fix:.
Cast the stdClass object to an array in order to access to its key "public". 
Tested with php 5.2.8, do you have the chance to double check it.. or maybe you have some other idea.

against 3.3.22 build