### PR TITLE
FIX : recursive creation of iphonecheckcontainer

### DIFF
--- a/inc/admin/class-admin-meta_boxes.php
+++ b/inc/admin/class-admin-meta_boxes.php
@@ -228,13 +228,15 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
             </div>
             <div class="meta-box-item-content">
               <input name="tc_post_id" id="tc_post_id" type="hidden" value="<?php echo $post-> ID ?>"/>
-               <?php
-                 $post_slider_checked = false;
-                 if ( $post_slider_check_value == 1)
-                  $post_slider_checked = true;
-                ?>
-              <input name="<?php echo $post_slider_check_id; ?>" type="hidden" value="0"/>
-              <input name="<?php echo $post_slider_check_id ?>" id="<?php echo $post_slider_check_id; ?>" type="checkbox" class="iphonecheck" value="1" <?php checked( $post_slider_checked, $current = true, $echo = true ) ?>/>
+              <div id="ihpone_check_box">
+                 <?php
+                   $post_slider_checked = false;
+                   if ( $post_slider_check_value == 1)
+                    $post_slider_checked = true;
+                  ?>
+                <input name="<?php echo $post_slider_check_id; ?>" type="hidden" value="0"/>
+                <input name="<?php echo $post_slider_check_id ?>" id="<?php echo $post_slider_check_id; ?>" type="checkbox" class="iphonecheck" value="1" <?php checked( $post_slider_checked, $current = true, $echo = true ) ?>/>
+              </div>
             </div>
             <div id="post_slider_infos">
               <?php do_action( '__post_slider_infos' , $post -> ID ); ?>


### PR DESCRIPTION
On post/page metas, the slider for page selection , after clicking the YES/NO iphonechacheckbox it generates a new div "iphonecheckcontainer" nested under "iphonecheckcontainer". it reproduces after every checked change, and happens only here.
This "funny" change - wrapping the inputs with div, does the fix.

Maybe there's a better way to fix it in the js functions?