### PR TITLE
Fix: whene deleting retina images don't forget the original attachmen…

### DIFF
--- a/inc/class-fire-init.php
+++ b/inc/class-fire-init.php
@@ -634,28 +634,24 @@ if ( ! class_exists( 'TC_init' ) ) :
      * @credits http://wp.tutsplus.com/author/chrisbavota/
      */
       function tc_clean_retina_images( $attachment_id ) {
-        //checks if retina is enabled in options
-        if ( 0 == TC_utils::$inst->tc_opt( 'tc_retina_support' ) )
-          return;
-
         $meta = wp_get_attachment_metadata( $attachment_id );
         if ( !isset( $meta['file']) )
           return;
 
         $upload_dir = wp_upload_dir();
         $path = pathinfo( $meta['file'] );
-        foreach ( $meta as $key => $value ) {
-            if ( 'sizes' === $key ) {
-                foreach ( $value as $sizes => $size ) {
-                    $original_filename = $upload_dir['basedir'] . '/' . $path['dirname'] . '/' . $size['file'];
-                    $retina_filename = substr_replace( $original_filename, '@2x.', strrpos( $original_filename, '.' ), strlen( '.' ) );
-                    if ( file_exists( $retina_filename ) )
-                        unlink( $retina_filename );
-                }
-            }
+        $sizes = $meta['sizes'];
+        // append to the sizes the original file
+        $sizes['original'] = array( 'file' => $path['basename'] );
+
+        foreach ( $sizes as $size ) {
+          $original_filename = $upload_dir['basedir'] . '/' . $path['dirname'] . '/' . $size['file'];
+          $retina_filename = substr_replace( $original_filename, '@2x.', strrpos( $original_filename, '.' ), strlen( '.' ) );
+
+          if ( file_exists( $retina_filename ) )
+            unlink( $retina_filename );
         }
       }//end of function
-
 
 
       /**


### PR DESCRIPTION
…t's retina version

Reported here:
http://presscustomizr.com/support-forums/topic/2x-version-image-is-not-deleted/
Basically the retina version of the original attachment (base size) isn't removed, that's cause we cycle on the sizes metadata of the attachment.

What this PR does:
1) remove the check on retina option enabled, 'cause I think we have to remove them even if that option is disabled. Scenario:
- Retina enabled ; media uploaded; retina files created
- user disable the retina option; then delete an attachment
- retina images aren't deleted. 
I think is wrong

2) Add the original attachment file to the list of the "sizes" to cycle through

3) Simplify the cycle: cycle only on the sizes metadata.

against 54c965cd59