### PR TITLE
Sticky header trigger height

### DIFF
--- a/inc/assets/js/parts/bootstrap.js
+++ b/inc/assets/js/parts/bootstrap.js
@@ -1687,6 +1687,7 @@ var TCParams = TCParams || {};
       //@tc adddon
       if ( TCParams && 1 != TCParams.dropdowntoViewport && 1 == TCParams.stickyHeader ) {
         $('body').addClass('tc-sticky-header');
+        $(window).trigger('resize');
       }
     }
 

--- a/inc/assets/js/parts/main.js
+++ b/inc/assets/js/parts/main.js
@@ -495,9 +495,9 @@ jQuery(function ($) {
         $resetMarginTop.css('margin-top' , '' ).show();
 
         //What is the initial offset of the header ?
-        var headerHeight    = $tcHeader.outerHeight(true); /* include borders and eventual margins (true param)*/
+        var headerHeight    = $tcHeader.outerHeight(true), /* include borders and eventual margins (true param)*/
             //initial margin-top = initial offset + header's height
-            marginTop       = initial headerHeight + customOffset;
+            marginTop       = headerHeight + customOffset;
         //set initial margin-top 
         $resetMarginTop.css('margin-top' , marginTop + 'px');
         //set trigger height as the half marginTop

--- a/inc/assets/js/parts/main.js
+++ b/inc/assets/js/parts/main.js
@@ -462,7 +462,8 @@ jQuery(function ($) {
           customOffset    = +_p.stickyCustomOffset,
           $sticky_logo    = $('img.sticky', '.site-logo'),
           $resetMarginTop = $('#tc-reset-margin-top'),
-          logo            = 0 === $sticky_logo.length ? { _logo: $('img:not(".sticky")', '.site-logo') , _ratio: '' }: false;
+          logo            = 0 === $sticky_logo.length ? { _logo: $('img:not(".sticky")', '.site-logo') , _ratio: '' }: false,
+          triggerHeight   = 20;
 
     function _is_scrolling() {
         return $_body.hasClass('sticky-enabled') ? true : false;
@@ -479,7 +480,7 @@ jQuery(function ($) {
             if ( 580 < $_window.width() )
                 initialOffset = $wpadminbar.height();
             else
-                initialOffset = ! _is_scrolling() ? $wpadminbar.height() : 0;
+                initialOffset = ! $_window.scrollTop() ? $wpadminbar.height() : 0;
         }
         return initialOffset + customOffset;
     }
@@ -495,8 +496,12 @@ jQuery(function ($) {
 
         //What is the initial offset of the header ?
         var headerHeight    = $tcHeader.outerHeight(true); /* include borders and eventual margins (true param)*/
-        //set initial margin-top = initial offset + header's height
-        $resetMarginTop.css('margin-top' , ( +headerHeight + customOffset ) + 'px');
+            //initial margin-top = initial offset + header's height
+            marginTop       = initial headerHeight + customOffset;
+        //set initial margin-top 
+        $resetMarginTop.css('margin-top' , marginTop + 'px');
+        //set trigger height as the half marginTop
+        triggerHeight       = martinTop/2;
     }
 
 
@@ -557,9 +562,6 @@ jQuery(function ($) {
     //SCROLLING ACTIONS
     var timer,
         increment = 1;//used to wait a little bit after the first user scroll actions to trigger the timer
-
-    //var windowHeight = $(window).height();
-    var triggerHeight = 20; //0.5 * windowHeight;
 
     function _sticky_header_scrolling_actions() {
         _set_header_top_offset();

--- a/inc/assets/js/parts/main.js
+++ b/inc/assets/js/parts/main.js
@@ -501,7 +501,7 @@ jQuery(function ($) {
         //set initial margin-top 
         $resetMarginTop.css('margin-top' , marginTop + 'px');
         //set trigger height as the half marginTop
-        triggerHeight       = martinTop/2;
+        triggerHeight       = marginTop && marginTop/2 > triggerHeight ? marginTop/2 : triggerHeight;
     }
 
 


### PR DESCRIPTION
This is my idea to avoid the huge gap when starting the scroll below the sticky header.
I set the tiggerHeight as half the marginTop, maybe we can change it, in any case I think it should be, if not custom, a percentage of the #tc-reset-margin-top's margin-top . (maybe 2/3 could be even better when logo centered).

You might like or not this but there are two (independent) additional fixes in it (I might do another PR but since are 2 lines..).

Scenario for the bootstrap.js change:
- adminbar on , tc-sticky-header on, dropdowntoViewport off, so "In responsive mode, limit the height of the dropdown menu block to the visible viewport" unchecked. 
- scroll down the page for a certain amount (so the header top will be set to 0), click on the menu button, page will scrolled up and menu will be shown (sticky disabled)
- click again on the menu, sticky re-enabled but top is set to 0 so the adminbar will overlap the header, or if you prefer the header will go behind the adminbar :D 
I trigger a resize so the header's offset will be set again. We might consider to make custom signals so we can better control this stuff without trigger a window resize.

Scenario for "initialOffset = ! $_window.scrollTop() ? $wpadminbar.height() : 0;" change:
- adminbar on, tc-sticky-header on
- scroll down the page just ONE step, you'll see the sticky header enabled having an useless top property = adminbar height, so blank gap

My solution is to refer to the window scrollTop in that case instead of relying on _is_scrolling()
