### PR TITLE
Fix: better handling of the post metas hiding in customize

### DIFF
--- a/inc/admin/js/theme-customizer-preview.js
+++ b/inc/admin/js/theme-customizer-preview.js
@@ -175,41 +175,45 @@
 		} );
 	});
 
-	//Post metas
+    //Post metas
+    var _post_metas_context = [
+          { _context : 'home', _container : '.home' },
+          { _context : 'single_post', _container: '.single'},
+          { _context : 'post_lists', _container: 'body:not(.single, .home)'}
+        ];
+
 	wp.customize( 'tc_theme_options[tc_show_post_metas]' , function( value ) {
 		value.bind( function( to ) {
+            var $_entry_meta = $('.entry-header .entry-meta', '.article-container');
 			if ( false === to )
-				$('.entry-header .entry-meta' , '.article-container').hide('slow');
+				$_entry_meta.hide('slow');
             else if (! $('body').hasClass('hide-post-metas') ){
-				$('.entry-header .entry-meta' , '.article-container').show('fast');
+				$_entry_meta.show('fast');
                 $('body').removeClass('hide-all-post-metas');
             }
 		} );
 	} );
-	wp.customize( 'tc_theme_options[tc_show_post_metas_home]' , function( value ) {
-		value.bind( function( to ) {
-			if ( false === to )
-				$('.entry-header .entry-meta' , '.home .article-container').hide('slow');
-			else
-				$('.entry-header .entry-meta' , '.home .article-container').show('fast');
-		} );
-	});
-	wp.customize( 'tc_theme_options[tc_show_post_metas_single_post]' , function( value ) {
-		value.bind( function( to ) {
-			if ( false === to )
-				$('.entry-header .entry-meta' , '.single .article-container').hide('slow');
-			else
-				$('.entry-header .entry-meta' , '.single .article-container').show('fast');
-		} );
-	});
-	wp.customize( 'tc_theme_options[tc_show_post_metas_post_lists]' , function( value ) {
-		value.bind( function( to ) {
-			if ( false === to )
-				$('.entry-header .entry-meta' , '.article-container').not('.single').hide('slow');
-			else
-				$('.entry-header .entry-meta' , '.article-container').not('.single').show('fast');
-		} );
-	});
+    
+    $.each( _post_metas_context, function() {
+        var $_post_metas = $('.entry-header .entry-meta', this._container + ' .article-container' );
+        if ( $_post_metas.length > 0 ){
+            wp.customize( 'tc_theme_options[tc_show_post_metas_' + this._context + ']' , function( value ) {
+                value.bind( function( to ) {
+                    if ( false === to ){
+                      $_post_metas.hide('slow');
+                      $('body').addClass('hide-post-metas');
+                    }else{
+                      $_post_metas.show('fast');
+                      $('body').removeClass('hide-post-metas');
+                    }
+                } );
+            });
+            // if we matched a context break
+            return false;
+        }
+    }); /* end contextual post metas*/
+
+    // Link hover effect
 	wp.customize( 'tc_theme_options[tc_link_hover_effect]' , function( value ) {
 		value.bind( function( to ) {
 			if ( false === to )
@@ -218,11 +222,12 @@
 				$('body').addClass('tc-fade-hover-links');
 		} );
 	});
+
     //Posts navigation
     var _post_nav_context = [
-          { _context : 'page', _selector : 'body.page' },
-          { _context : 'single', _selector: 'body.single'},
-          { _context : 'archive', _selector: 'body.archive'}
+          { _context : 'page', _container : 'body.page' },
+          { _context : 'single', _container: 'body.single'},
+          { _context : 'archive', _container: 'body.archive'}
         ];
 
 	wp.customize( 'tc_theme_options[tc_show_post_navigation]' , function( value ) {
@@ -236,8 +241,8 @@
 	  } );
 
     $.each( _post_nav_context, function() {
-        var $_post_nav = $('#nav-below', this._selector );
-        if ( $_post_nav.length > 0 )
+        var $_post_nav = $('#nav-below', this._container );
+        if ( $_post_nav.length > 0 ){
             wp.customize( 'tc_theme_options[tc_show_post_navigation_' + this._context + ']' , function( value ) {
                 value.bind( function( to ) {
                     if ( false === to )
@@ -246,6 +251,9 @@
                       $_post_nav.show('fast').removeClass('hide-post-navigation');
                 } );
             });
+            // if we matched a context break
+            return false;
+        }
     }); /* end contextual post nav*/
 
     //Post thumbnails


### PR DESCRIPTION
against 572e75679e

Same method used for the post navigation.

How to reproduce the issue:
Use case:
1) start with metas visible "Display posts metas" and in singles "Display posts metas for single posts
" , so move in single context.
2) hide single metas -> unceck "Display posts metas for single posts"
3) hide all metas -> uncheck "Display posts metas"
4) display all metas -> check again "Display posts metas"
you'll see the metas in single context appearing again.

This pull-request fixes that, also fixes another small bug, which hid the post metas in all the context when unchecking "Display posts metas in post lists (archives, blog page)" because of the "wrong" selector used (using .not('.single') here -> https://github.com/Nikeo/customizr/blob/master/inc/admin/js/theme-customizer-preview.js#L208 (and 210) didn't work since applied to the whole retrieved meta element, which of course never has the "single" class).

Tests:
1)  in home displaying latest posts:
- All options checked:  the only two options affecting post metas are correctly "Display posts metas" and "Display posts metas on home"
- All context options unchecked main option checked: the only two options affecting post metas are correctly "Display posts metas" and "Display posts metas on home"
- Main option unchecked: the only two options affecting post metas are correctly "Display posts metas" and "Display posts metas on home"

2) in single context:
- All options checked:  the only two options affecting post metas are correctly "Display posts metas" and "Display posts metas for single posts"
- All context options unchecked, main option checked: the only two options affecting post metas are correctly "Display posts metas" and "Display posts metas for single posts"
- Main option unchecked: the only two options affecting post metas are correctly "Display posts metas" and "Display posts metas for single posts"

3) in categories and author's page:
- All options checked:  the only two options affecting post metas are correctly "Display posts metas" and "Display posts metas in post lists (archives ...)"
- All context options unchecked, main option checked: the only two options affecting post metas are correctly "Display posts metas" and "Display posts metas in post lists (archives ...)"
- Main option unchecked: the only two options affecting post metas are correctly "Display posts metas" and "Display posts metas in post lists (archives ...)"

4) Use case reported above:
no bug encountered.

Final response: should be fine :P


  