### PR TITLE
Fix: check if get_term_link returns a WP_Error: compatibility with ol…

### DIFF
--- a/inc/parts/class-content-post_metas.php
+++ b/inc/parts/class-content-post_metas.php
@@ -361,9 +361,13 @@ if ( ! class_exists( 'TC_post_metas' ) ) :
             array_push( $_classes , 'btn-tag' );
 
           $_classes      = implode( ' ', apply_filters( 'tc_meta_tax_class', $_classes , isset( $term -> category_parent ) ) );
-          return apply_filters( 'tc_meta_term_view' , sprintf('<a class="%1$s" href="%2$s" title="%3$s"> %4$s </a>',
+          $_term_link    = is_wp_error( get_term_link( $term ) ) ? '' : get_term_link( $term );
+
+          $_to_return    = $_term_link ? '<a class="%1$s" href="%2$s" title="%3$s"> %4$s </a>' :  '<span class="%1$s"> %4$s </a>';
+
+          return apply_filters( 'tc_meta_term_view' , sprintf($_to_return,
               $_classes,
-              get_term_link( $term -> term_id , $term -> taxonomy ),
+              $_term_link,
               esc_attr( sprintf( __( "View all posts in %s", 'customizr' ), $term -> name ) ),
               $term -> name
             )


### PR DESCRIPTION
…d wp

against 572e756

Following to this https://wordpress.org/support/topic/empty-articles-when-upgrading-to-customizr-version-332

I found that at least wp 3.6.1 
[get_term_link($term->term_id, $term->taxonomy)]( https://github.com/Nikeo/customizr/blob/dev/inc/parts/class-content-post_metas.php#L366 )

returns a WP_Error 
Looking at the [codex](https://codex.wordpress.org/Function_Reference/get_term_link#Examples), looks like we can just use get_term_link($term), when $term is a term object. Just this change avoids the issue with 3.6.1, but I thought should be better make a check anyway on the return type of that function.

I tested it and looks we don't have issues... but, don't know, maybe I'm missing something.