### PR TITLE
Fix: exclude page and attachment post types when including cpt in arc…

### DIFF
--- a/inc/parts/class-content-post_list.php
+++ b/inc/parts/class-content-post_list.php
@@ -345,7 +345,10 @@ class TC_post_list {
       return;
 
     //filter the post types to include, they must be public and not excluded from search
-    $post_types     = get_post_types( array( 'public' => true, 'exclude_from_search' => false) );
+    //we also exclude the built-in types, to exclude pages and attachments, we'll add standard posts later
+    $post_types         = get_post_types( array( 'public' => true, 'exclude_from_search' => false, '_builtin' => false) );
+    //add standard post
+    $post_types['post'] = 'post';
 
     $query->set('post_type', $post_types );
   }


### PR DESCRIPTION
Following to:
https://wordpress.org/support/topic/custom-post-type-in-search-and-author-archive-and-date-archive?replies=21

The problem is that when we include cpt in archives we set the query var 'post_type' as the array retrieved from get_post_types.
That array contains also page and attachment post types.

With this code:
1) we get just "custom post types" instructing get_post_types to exclude buit-in types
2) we add to this retrieved array the standard wordpress post type.