### PR TITLE
Fix: fix post-navigation regression introduced while merging rtl code

### DIFF
--- a/inc/parts/class-content-post_navigation.php
+++ b/inc/parts/class-content-post_navigation.php
@@ -67,10 +67,6 @@ if ( ! class_exists( 'TC_post_navigation' ) ) :
       function tc_post_nav() {
 
         list( $post_navigation_bool, $post_nav_class, $_context) = $this -> tc_set_visibility_options();
-        // When do we display navigation ?
-        //1) we don"t show post navigation for pages by default
-        //2) + filter conditions
-        $post_navigation_bool         = is_page( TC_utils::tc_id() ) ? false : true ;
 
         if( ! $post_navigation_bool )
           return;


### PR DESCRIPTION
This regression forced the hiding of the psot-navigation in pages (we have an option now) and the showing in any other context, overriding the filtered boolean state (see post-navigation shown in bbpress).