### PR TITLE
Fix: sum in less file for media query

### DIFF
--- a/inc/assets/less/tc_variables.less
+++ b/inc/assets/less/tc_variables.less
@@ -253,7 +253,7 @@
 // Navbar
 // -------------------------
 @navbarCollapseWidth:             979px;
-@navbarCollapseDesktopWidth:      @navbarCollapseWidth + 1;
+@navbarCollapseDesktopWidth:      (@navbarCollapseWidth + 1);
 
 @navbarHeight:                    40px;
 @lnkColnavbarBtnHighlight: 			  @lnkCol;


### PR DESCRIPTION
That line produced this -> https://github.com/Nikeo/customizr/blob/master/inc/assets/css/tc_common.css#L8303
Which is something wrong, but oddly enough was still evaluated by ie11 :D 
That's the reason of the bug in #54 (which I close now.)
