### PR TITLE
Fix: when unhooking tc_parse_imgs for nextgen compatibility use prope…

### DIFF
--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -311,7 +311,7 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
        if ( is_page() || is_admin() || 0 == esc_attr( TC_utils::$inst->tc_opt( 'tc_img_smart_load' ) ) )
         return;
 
-       remove_filter('the_content', array(TC_utils::$instance, 'tc_parse_imgs') );
+       remove_filter('the_content', array(TC_utils::$instance, 'tc_parse_imgs'), 20 );
        // they add the actual images filtering the content with priority PHP_INT_MAX -1
        add_filter('the_content'   , array(TC_utils::$instance, 'tc_parse_imgs'), PHP_INT_MAX );
      }


### PR DESCRIPTION
…r priority

Following to commit c601d8a we have to use the proper priority, again ..  my bad.
p.s.
not a major issue anyway, the only thing is that the filter was not unhooked, so tc_parse_imgs was called twice.