### PR TITLE
Fix: better rtl slide controls and swiping(js)

### DIFF
--- a/inc/assets/js/parts/main.js
+++ b/inc/assets/js/parts/main.js
@@ -127,11 +127,12 @@ jQuery(function ($) {
         });
 
         $('.carousel' ).each( function() {
+            var _is_rtl = $('body').hasClass('rtl');
             $(this).hammer().on('swipeleft tap', function() {
-                $(this).carousel('next');
+                $(this).carousel( ! _is_rtl ? 'next' : 'prev' );
             });
             $(this).hammer().on('swiperight', function(){
-                $(this).carousel('prev');
+                $(this).carousel( ! _is_rtl ? 'prev' : 'next' );
             });
         });
     }

--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -369,15 +369,13 @@ class TC_slider {
     $_html = '';
     $_html .= sprintf('<div class="tc-slider-controls %1$s">%2$s</div>',
       ! is_rtl() ? 'left' : 'right',
-      sprintf('<a class="tc-carousel-control" href="#customizr-slider" data-slide="%1$s">%2$s</a>',
-        ! is_rtl() ? 'prev' : 'next',
+      sprintf('<a class="tc-carousel-control" href="#customizr-slider" data-slide="prev">%1$s</a>',
         apply_filters( 'tc_slide_left_control', '&lsaquo;' )
       )
     );
     $_html .= sprintf('<div class="tc-slider-controls %1$s">%2$s</div>',
       ! is_rtl() ? 'right' : 'left',
-      sprintf('<a class="tc-carousel-control" href="#customizr-slider" data-slide="%1$s">%2$s</a>',
-        ! is_rtl() ? 'next' : 'prev',
+      sprintf('<a class="tc-carousel-control" href="#customizr-slider" data-slide="next">%1$s</a>',
         apply_filters( 'tc_slide_right_control', '&rsaquo;' )
       )
     );


### PR DESCRIPTION
Following to this:
https://wordpress.org/support/topic/slider-problem-after-last-update

1) slider class:
old code basically didn't change the slid direction, as you can see "left" meant always "prev" and "right" always "next". In rtl right -> prev , left -> next , so we have to change just the left/right class.

2)js swipeleft/right: (still on the old main.js)
if I get the issue, swiping to the left, in rtl, should replicate "prev" and swiping to the right "next"

@JTS-IL consultancy would be very helpful :)