### PR TITLE
Fix: some ie8 fixes for the new front-js

### DIFF
--- a/inc/assets/js/parts/_main_base.part.js
+++ b/inc/assets/js/parts/_main_base.part.js
@@ -1,4 +1,20 @@
 var czrapp = czrapp || {};
+/* Object.create monkey patch ie8 http://stackoverflow.com/a/18020326
+ * Shoudl be probablly moved in a different file. 
+ * I think we can make an "old-browser-comp" file where to move this, arrayPrototype and further patches of the same kind
+ *
+ * */
+if ( !Object.create ) {
+  Object.create = function(proto, props) {
+    if (typeof props !== "undefined") {
+      throw "The multiple-argument version of Object.create is not provided by this browser and cannot be shimmed.";
+    }
+    function ctor() { }
+    
+    ctor.prototype = proto;
+    return new ctor();
+  };
+}
 
 (function($, czrapp) {
   // if ( ! TCParams || _.isEmpty(TCParams) )
@@ -111,7 +127,7 @@ var czrapp = czrapp || {};
       var self = this;
       _.map( cbs, function(cb) {
         if ( 'function' == typeof(self[cb]) ) {
-          self[cb].apply(self, args);
+          self[cb].apply(self, 'undefined' == typeof( args ) ? Array() : args );
           czrapp.$_body.trigger( cb, _.object( _.keys(args), args ) );
         }
       });//_.map

--- a/inc/assets/js/parts/_main_jquery_plugins.part.js
+++ b/inc/assets/js/parts/_main_jquery_plugins.part.js
@@ -5,8 +5,9 @@ var czrapp = czrapp || {};
 (function($, czrapp) {
   var _methods = {
     centerImagesWithDelay : function( delay ) {
+      var self = this;  
       //fire the center images plugin
-      setTimeout( this.emit('centerImages'), delay || 300 );
+      setTimeout( function(){ self.emit('centerImages'); }, delay || 300 );
     },
 
 


### PR DESCRIPTION
I tested the new front-js with ie8 and I found the following issues:
1) Object.create doesn't exist in ie8 . In this PR a monkey patch I put in _main_base.part.js mainly as "reminder" 'cause I think we have to put it in a better place, as explained in the inline comment

2) Looks like passing a type of undefined as argument of jQuery.apply() breaks in ie8. It also requires args being an Array() anyways

3) this.emit(string) isn't a valid callback for setTimeout in ie8. It requires a function or the callback as string.

