### PR TITLE
Fix: use original img sizes

### DIFF
--- a/grunt-tasks-config/concat.js
+++ b/grunt-tasks-config/concat.js
@@ -7,7 +7,7 @@ module.exports = {
     dest: '<%= paths.front_js %>parts/main.js',
   },
   front_js: {
-		src: ['<%= paths.front_js %>parts/tc-js-params.js', '<%= paths.front_js %>parts/arrayPrototypeMap.js', '<%= paths.front_js %>parts/bootstrap.js', '<%= paths.front_js %>parts/underscore-min.js', '<%= paths.front_js %>parts/jqueryaddDropCap.js', '<%= paths.front_js %>parts/jqueryimgSmartLoad.js', '<%= paths.front_js %>parts/jqueryextLinks.js', '<%= paths.front_js %>parts/jqueryCenterImages.js', '<%= paths.front_js %>parts/main.js'],
+		src: ['<%= paths.front_js %>parts/tc-js-params.js', '<%= paths.front_js %>parts/arrayPrototypeMap.js', '<%= paths.front_js %>parts/bootstrap.js', '<%= paths.front_js %>parts/underscore-min.js', '<%= paths.front_js %>parts/jqueryimgOriginalSizes.js', '<%= paths.front_js %>parts/jqueryaddDropCap.js', '<%= paths.front_js %>parts/jqueryimgSmartLoad.js', '<%= paths.front_js %>parts/jqueryextLinks.js', '<%= paths.front_js %>parts/jqueryCenterImages.js', '<%= paths.front_js %>parts/main.js'],
 		dest: '<%= paths.front_js %>tc-scripts.js',
 	},
 	admin_control_js:{

--- a/inc/assets/js/parts/_main_base.part.js
+++ b/inc/assets/js/parts/_main_base.part.js
@@ -70,6 +70,7 @@ var czrapp = czrapp || {};
       $.extend( czrapp, {
         //cache various jQuery el in czrapp obj
         $_window         : $(window),
+        $_html           : $('html'),
         $_body           : $('body'),
         $_tcHeader       : $('.tc-header'),
         $_wpadminbar     : $('#wpadminbar'),

--- a/inc/assets/js/parts/_main_sticky_header.part.js
+++ b/inc/assets/js/parts/_main_sticky_header.part.js
@@ -55,6 +55,7 @@ var czrapp = czrapp || {};
 
       switch ( evt ) {
         case 'on-load' :
+          self._prepare_logo_transition();
           setTimeout( function() {
             self._sticky_refresh();
             self._sticky_header_scrolling_actions();
@@ -133,6 +134,24 @@ var czrapp = czrapp || {};
       var self = this;
       //set header initial offset
       czrapp.$_tcHeader.css('top' , self._get_initial_offset() );
+    },
+
+    //STICKY HEADER SUB CLASS HELPER (private like)
+    _prepare_logo_transition : function(){ 
+      //do nothing if the browser doesn't support csstransitions (modernizr)
+      //or if no logo (includes the case where we have two logos, normal and sticky one)
+      if ( ! ( czrapp.$_html.hasClass('csstransitions') && ( this.logo && 0 !== this.logo._logo.length ) ) )
+        return;
+
+      var logoW = this.logo._logo.originalWidth(),
+          logoH = this.logo._logo.originalHeight();
+      
+      //check that all numbers are valid before using division
+      if ( 0 === _.size( _.filter( [ logoW, logoH ], function(num){ return _.isNumber( parseInt(num, 10) ) && 0 !== num; } ) ) )
+        return;
+    
+      this.logo._ratio = logoW / logoH;
+      this.logo._logo.css('width' , logoW );
     },
 
     //STICKY HEADER SUB CLASS HELPER (private like)

--- a/inc/assets/js/parts/jqueryCenterImages.js
+++ b/inc/assets/js/parts/jqueryCenterImages.js
@@ -174,12 +174,14 @@
     if ( $_img.is(":visible") )
       return 'x' == _dim ? $_img.outerWidth() : $_img.outerHeight();
     else {
-      if ( 'x' == _dim && $_img.attr('width') )
-        return $_img.attr('width');
-      if ( 'y' == _dim && $_img.attr('height') )
-        return $_img.attr('height');
+      if ( 'x' == _dim ){
+        var _width = $_img.originalWidth();  
+        return typeof _width === undefined ? 0 : _width;
+      }if ( 'y' == _dim ){
+        var _height = $_img.originalHeight();  
+        return typeof _height === undefined ? 0 : _height;
+      }
     }
-    return 0;
   };
 
 

--- a/inc/assets/js/parts/jqueryimgOriginalSizes.js
+++ b/inc/assets/js/parts/jqueryimgOriginalSizes.js
@@ -1,0 +1,53 @@
+/* ===================================================
+ * jqueryimgOriginalSizes.js v1.0.0
+ * ===================================================
+ * (c) 2015 Nicolas Guillaume, Nice, France - Rocco Aliberti, Salerno, Italy
+ * CenterImages plugin may be freely distributed under the terms of the GNU GPL v2.0 or later license.
+ *
+ * Heavily based on http://www.jacklmoore.com/notes/naturalwidth-and-naturalheight-in-ie/
+ *
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * Retrieves the original imgs width and height, cross-browser
+ *
+ * Example usage
+ * var imgHeight = $('img#my-img').originalHeight(),
+ *     imgWidth  = $('img#my-img').originalWidth()
+ *
+ * =================================================== */
+;(function ( $, window, document, undefined ) {
+
+  var pluginPrefix = 'original',
+      _props       = ['Width', 'Height'];
+
+  while (_prop = _props.pop()) {
+    (function ( _prop, _lprop ) {
+      $.fn[ pluginPrefix + _prop ] = ('natural' + _prop in new Image()) ? 
+        function () {
+          return this[0][ 'natural' + _prop ];
+        } : 
+        function () {
+          var _size = _getAttr( this, l_prop );
+        
+          if ( _size )
+            return _size;
+
+          var _node = this[0],
+              _img;
+
+          if (_node.tagName.toLowerCase() === 'img') {
+            _img = new Image();
+            _img.src = _node.src,
+            _size = _img[ _lprop ];
+          }
+          return _size;
+        };
+    }( _prop, _prop.toLowerCase()));
+  }
+
+  function _getAttr( _el, prop ){
+    var _img_size = $(_el).attr( prop );  
+    return ( typeof _img_size === undefined ) ? false : _img_size;     
+  }
+
+})( jQuery, window, document );

--- a/inc/class-fire-resources.php
+++ b/inc/class-fire-resources.php
@@ -87,6 +87,11 @@ if ( ! class_exists( 'TC_resources' ) ) :
           'files' => array( 'bootstrap.js' , 'bootstrap.min.js' ),
           'dependencies' => array( 'tc-js-arraymap-proto', 'jquery', 'tc-js-params' )
         ),
+        'tc-img-original-sizes' => array(
+          'path' => 'inc/assets/js/parts/',
+          'files' => array( 'jqueryimgOriginalSizes.js' ),
+          'dependencies' => array('jquery')
+        ),
         'tc-dropcap' => array(
           'path' => 'inc/assets/js/parts/',
           'files' => array( 'jqueryaddDropCap.js' ),
@@ -105,13 +110,13 @@ if ( ! class_exists( 'TC_resources' ) ) :
         'tc-center-images' => array(
           'path' => 'inc/assets/js/parts/',
           'files' => array( 'jqueryCenterImages.js' ),
-          'dependencies' => array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-bootstrap', 'underscore' )
+          'dependencies' => array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-img-original-sizes', 'tc-bootstrap', 'underscore' )
         ),
         //!!no fancybox dependency if fancybox not required!
         'tc-main-front' => array(
           'path' => 'inc/assets/js/parts/',
           'files' => array( 'main.js' , 'main.min.js' ),
-          'dependencies' => $this -> tc_is_fancyboxjs_required() ? array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-bootstrap', 'tc-fancybox' , 'underscore' ) : array( 'jquery' , 'tc-js-params', 'tc-bootstrap' , 'underscore' )
+          'dependencies' => $this -> tc_is_fancyboxjs_required() ? array( 'tc-js-arraymap-proto', 'jquery' , 'tc-js-params', 'tc-img-original-sizes', 'tc-bootstrap', 'tc-fancybox' , 'underscore' ) : array( 'jquery' , 'tc-js-params', 'tc-img-original-sizes', 'tc-bootstrap' , 'underscore' )
         ),
         //loaded separately => not included in tc-script.js
         'tc-fancybox' => array(
@@ -162,7 +167,7 @@ if ( ! class_exists( 'TC_resources' ) ) :
 			else {
         wp_enqueue_script( 'underscore' );
         //!!mind the dependencies
-        $this -> tc_enqueue_script( array( 'tc-js-params', 'tc-js-arraymap-proto', 'tc-bootstrap' ) );
+        $this -> tc_enqueue_script( array( 'tc-js-params', 'tc-js-arraymap-proto', 'tc-img-original-sizes', 'tc-bootstrap' ) );
 
         if ( $this -> tc_is_fancyboxjs_required() )
           $this -> tc_enqueue_script( 'tc-fancybox' );


### PR DESCRIPTION
against 4994c9

What this PR affects to:
1) Sticky logo transition:
1.a) re-introduce the logo ratio computation in the sticky header part (was lost due to a typo in the recent front revamp) to allow logo transition, just when the browser supports css transitions
1.b) don't set the height on page load, will be set later on 'resize' event fired by the sticky header
2) Retrieving of the natural/original img sizes:
Both in the logo ratio maths above and when centering hidden slider's slides we refer to the img attributes width and height. The problem is that jetpack's photon (CDN) doesn't provide these attributes. Also retina.js messes with them. We introduce then a new jquery "function" to retrieve the natural sizes, cross-browser. My first thought was to always fallback on these attributes when present whether or not the naturalWidth/Height was available. The problem is that retina.js serves images with sizes in pixels different from the attribute values. Basically, for example, attr width != naturalWidth . Since this happens just with retina imgs I left the fallback on attributes just when the browser's doesn't support naturalWidth/Height (old browsers like ie8 and below)  which pretty unlikely will run on retina devices ... I hope :D
