### PR TITLE
Fix: do not add no-effect class to round-divs when center images on

### DIFF
--- a/inc/parts/class-content-post_thumbnails.php
+++ b/inc/parts/class-content-post_thumbnails.php
@@ -225,8 +225,8 @@ class TC_post_thumbnails {
 
       //handles the case when the image dimensions are too small
       $thumb_size       = apply_filters( 'tc_thumb_size' , TC_init::$instance -> tc_thumb_size, TC_utils::tc_id()  );
-      $no_effect_class  = ( isset($tc_thumb) && isset($tc_thumb_height) && ( $tc_thumb_height < $thumb_size['width']) ) ? 'no-effect' : '';
-      $no_effect_class  = ( ! isset($tc_thumb) || empty($tc_thumb_height) || empty($tc_thumb_width) ) ? '' : $no_effect_class;
+      $no_effect_class  = ( isset($tc_thumb) && isset($tc_thumb_height) && ( $tc_thumb_height < $thumb_size['height']) ) ? 'no-effect' : '';
+      $no_effect_class  = ( esc_attr( TC_utils::$inst->tc_opt( 'tc_center_img') ) || ! isset($tc_thumb) || empty($tc_thumb_height) || empty($tc_thumb_width) ) ? '' : $no_effect_class;
 
       //default hover effect
       $thumb_wrapper    = sprintf('<div class="%5$s %1$s"><div class="round-div"></div><a class="round-div %1$s" href="%2$s" title="%3$s"></a>%4$s</div>',


### PR DESCRIPTION
Reported here:
http://presscustomizr.com/support-forums/topic/expanding-thumbnails-are-not-linked-completely-nothing-happens-on-mouse-click/

This is just a part of: #112

Still not sure why the condition was:
$tc_thumb_height < $thumb_size['width'])
I mean since the thumb size is 270x250 the height is normally always less than the width ..

Anyway the main aim of this PR is to not add the no-effect class when the "Dynamic thumbnails centering on any devices" option, is checked, because in that case the image will fit the thumb-wrapper.