### PR TITLE
Fix: allow img smartload in mobiles

### DIFF
--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       * @since Customizr 3.3.0
       */
       function tc_parse_imgs( $_html ) {
-        if( is_feed() || is_preview() || wp_is_mobile() )
+        if( is_feed() || is_preview() || ( wp_is_mobile() && apply_filters('tc_disable_img_smart_load_mobiles', false ) ) )
           return $_html;
 
         if ( strpos( $_html, 'data-src' ) !== false )


### PR DESCRIPTION
Allow img smartload in mobiles.
Tested with:
- LG 4X HD both with stock browser and chrome; Android 4.4.4 (not official rom)
- Samsung galaxy-tab SM-T310 both with stock browser and chrome; Android 4.4.2

Looks like it works fine.
I've added a filter too in case we have some issues.

Known issues:
Sometimes it fails to retrieve the holders, though this is something that happens in desktop mode too.
I don't think this is something we have to care about, normally people will not have holders in their featured pages imgs.