### PR TITLE
Fix: do not treat accented charachters as special chars

### DIFF
--- a/inc/assets/js/parts/jqueryaddDropCap.js
+++ b/inc/assets/js/parts/jqueryaddDropCap.js
@@ -203,7 +203,7 @@
   //@return : string
   Plugin.prototype._removeSpecChars = function( _expr , _replaceBy ) {
     _replaceBy = _replaceBy || '';
-    return 'string' == typeof(_expr) ? _expr.replace(/[^\w-]/g, _replaceBy ) : '';
+    return 'string' == typeof(_expr) ? _expr.replace(/[^\w-\?!\u00bf-\u00ff]/g, _replaceBy ) : '';
   };
 
   //@return : string or false


### PR DESCRIPTION
This just includes accented chars to the list of the allowed chars. They're expressed in [utf8](http://www.utf8-chartable.de/) , that should be fine 'cause we set the meta charset as utf8, right?
As you can see it also includes multiplication and division chars. I didn't think was worthwhile excluding them, who cares? :D 
I also added the quotation mark, the bang, and the upside down quotation mark. The latest thinking about spanish way to formulate questions.

What do you think?