### PR TITLE
Fix: cache slider model

### DIFF
--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'TC_slider' ) ) :
 class TC_slider {
 
   static $instance;
-  private $slider_model;
+  private $sliders_model;
 
   function __construct () {
     self::$instance =& $this;
@@ -186,9 +186,6 @@ class TC_slider {
   *
   */
   private function tc_get_slider_model() {
-    if ( isset( $this -> slider_model ) )
-      return $this -> slider_model;
-    
     global $wp_query;
 
     //Do we have a slider to display in this context ?
@@ -203,6 +200,9 @@ class TC_slider {
     if ( ! $this -> tc_is_slider_active( $queried_id) )
       return array();
 
+    if ( ! empty( $this -> sliders_model ) && is_array( $this -> sliders_model ) && array_key_exists( $slider_name_id, $this -> sliders_model ) )
+      return $this -> sliders_model[ $slider_name_id ];
+
     //gets slider options if any
     $layout_value                 = tc__f('__is_home') ? TC_utils::$inst->tc_opt( 'tc_slider_width' ) : esc_attr(get_post_meta( $queried_id, $key = 'slider_layout_key' , $single = true ));
     $layout_value                 = apply_filters( 'tc_slider_layout', $layout_value, $queried_id );
@@ -214,9 +214,9 @@ class TC_slider {
     //get slides
     $slides                       = $this -> tc_get_the_slides( $slider_name_id , $img_size );
 
-    $this -> slider_model         = compact( "slider_name_id", "slides", "layout_class" , "img_size" );
+    $this -> sliders_model[ $slider_name_id ]         = compact( "slider_name_id", "slides", "layout_class" , "img_size" );
 
-    return $this -> slider_model;
+    return $this -> sliders_model[ $slider_name_id ];
   }
 
 

--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -15,6 +15,7 @@ if ( ! class_exists( 'TC_slider' ) ) :
 class TC_slider {
 
   static $instance;
+  private $slider_model;
 
   function __construct () {
     self::$instance =& $this;
@@ -170,7 +171,7 @@ class TC_slider {
       $_loop_index++;
     }//end of slides loop
     //returns the slides or false if nothing
-    return ! empty($slides) ? $slides : false;
+    return apply_filters('tc_the_slides', ! empty($slides) ? $slides : false );
   }
 
 
@@ -185,6 +186,9 @@ class TC_slider {
   *
   */
   private function tc_get_slider_model() {
+    if ( isset( $this -> slider_model ) )
+      return $this -> slider_model;
+    
     global $wp_query;
 
     //Do we have a slider to display in this context ?
@@ -210,7 +214,9 @@ class TC_slider {
     //get slides
     $slides                       = $this -> tc_get_the_slides( $slider_name_id , $img_size );
 
-    return compact( "slider_name_id", "slides", "layout_class" , "img_size" );
+    $this -> slider_model         = compact( "slider_name_id", "slides", "layout_class" , "img_size" );
+
+    return $this -> slider_model;
   }
 
 


### PR DESCRIPTION
Reason:
We call tc_get_slider_model() more than once, so why don't cache the model the first time?
New filter to easily manipulate the slides array

If you agree with this can you merge it asap? I might make some other changes soon.

(I will push a similar caching for the featured pages, now that we retrieve the thumbs 2 times [see the check on whether or not enqueue holder.js], once I've done with my devs)