### PR TITLE
Fix: fix external link icon on multiple occurrences and exclude parents

### DIFF
--- a/inc/assets/js/parts/jqueryextLinks.js
+++ b/inc/assets/js/parts/jqueryextLinks.js
@@ -22,19 +22,22 @@
 
 
     Plugin.prototype.init = function() {
+      var $_external_icon = this.$_el.next('.tc-external');
       //if not eligible, then remove any remaining icon element and return
       //important => the element to remove is right after the current link element ( => use of '+' CSS operator )
       if ( ! this._is_eligible() ) {
-        if ( $( 'a[href*="' + this._href +'"] + .tc-external' ).length )
-          $( 'a[href*="' + this._href +'"] + .tc-external' ).remove();
+        if ( $_external_icon.length )
+          $_external_icon.remove();
         return;
       }
 
       //add the icon link, if not already there
-      if ( this.options.addIcon && ! $( 'a[href*="' + this._href +'"] + .tc-external' ).length ) {
+      if ( this.options.addIcon && 0 === $_external_icon.length ) {
         this.$_el.after('<span class="tc-external">');
       }
-      if ( this.options.newTab )
+
+      //add the target _blank, if not already there
+      if ( this.options.newTab && '_blank' != this.$_el.attr('target') )
         this.$_el.attr('target' , '_blank');
     };
 
@@ -68,17 +71,22 @@
     * @return boolean
     */
     Plugin.prototype._is_selector_allowed = function( requested_sel_type ) {
-      var sel_type = 'ids' == requested_sel_type ? 'id' : 'class';
+      var sel_type = 'ids' == requested_sel_type ? 'id' : 'class',
+          _selsToSkip   = this.options.skipSelectors[requested_sel_type];
+
+      //check if option is well formed
+      if ( 'object' != typeof(this.options.skipSelectors) || ! this.options.skipSelectors[requested_sel_type] || ! $.isArray( this.options.skipSelectors[requested_sel_type] ) || 0 === this.options.skipSelectors[requested_sel_type].length )
+        return true;
+
+      //has a forbidden parent?
+      if ( this.$_el.parents( _selsToSkip.map( function( _sel ){ return 'id' == sel_type ? '#' + _sel : '.' + _sel; } ).join(',') ).length > 0 )
+        return false;    
+
       //has requested sel ?
       if ( ! this.$_el.attr( sel_type ) )
         return true;
 
-      //check if option is well formed
-      if ( 'object' != typeof(this.options.skipSelectors) || ! this.options.skipSelectors[requested_sel_type] || ! $.isArray( this.options.skipSelectors[requested_sel_type] )  )
-        return true;
-
       var _elSels       = this.$_el.attr( sel_type ).split(' '),
-          _selsToSkip   = this.options.skipSelectors[requested_sel_type],
           _filtered     = _elSels.filter( function(classe) { return -1 != $.inArray( classe , _selsToSkip ) ;});
 
       //check if the filtered selectors array with the non authorized selectors is empty or not


### PR DESCRIPTION
While finding a solution to the bug reported [here](http://presscustomizr.com/support-forums/topic/single-post-page-header-is-not-transparent-when-scroll-on-others-pages-its-ok)
I've decided to add a small code to exclude also links which have a parent matching (id or class) the skip selectors param (_is_selector_allowed -> //has a forbidden parent?).

Let me know if you don't agree with it and I'll provide another PR without it ;)

The issue reported occurred because in the mailto subject there were quotes and double quotes. And those hurt:
```$( 'a[href*="' + this._href +'"] + .tc-external' )```

to avoid string manipulation in order to escape them I decided to just use the [$.next()](https://api.jquery.com/next/) on the already retrieved element (our link)

For a matter of pure [serendipity](https://en.wikipedia.org/wiki/Serendipity) the latest fixes also the bug which occurred when we had many occurrences of the same link, because in that case this check
 
``` if ( this.options.addIcon && ! $( 'a[href*="' + this._href +'"] + .tc-external' ).length )```

failed, 'cause the href was the same, so no external icon was added.

Bests