### PR TITLE
Fix: re-introduce btt-arrow handling in new front js

### DIFF
--- a/inc/assets/js/parts/_main_sticky_header.part.js
+++ b/inc/assets/js/parts/_main_sticky_header.part.js
@@ -13,8 +13,6 @@ var czrapp = czrapp || {};
       this.elToHide         = []; //[ '.social-block' , '.site-description' ],
       this.customOffset     = +TCParams.stickyCustomOffset;
       this.logo             = 0 === this.$_sticky_logo.length ? { _logo: $('img:not(".sticky")', '.site-logo') , _ratio: '' }: false;
-      this.timer            = 0;
-      this.increment        = 1;//used to wait a little bit after the first user scroll actions to trigger the timer
       this.triggerHeight    = 20; //0.5 * windowHeight;
     },//init()
 
@@ -40,7 +38,7 @@ var czrapp = czrapp || {};
         self.stickyHeaderEventHandler('resize');
       });
 
-      czrapp.$_window.scroll( function() {
+      czrapp.$_window.on('tc_scroll', function() {
         self.stickyHeaderEventHandler('scroll');
       });
     },
@@ -63,21 +61,7 @@ var czrapp = czrapp || {};
         break;
 
         case 'scroll' :
-           //use a timer
-          if ( this.timer) {
-            this.increment++;
-            clearTimeout(self.timer);
-          }
-
-          if ( 1 == TCParams.timerOnScrollAllBrowsers ) {
-            timer = setTimeout( function() {
-              self._sticky_header_scrolling_actions();
-            }, self.increment > 5 ? 50 : 0 );
-          } else if ( czrapp.$_body.hasClass('ie') ) {
-            timer = setTimeout( function() {
-              self._sticky_header_scrolling_actions();
-            }, self.increment > 5 ? 50 : 0 );
-          }
+          self._sticky_header_scrolling_actions();
         break;
 
         case 'resize' :

--- a/inc/assets/js/parts/_main_userxp.part.js
+++ b/inc/assets/js/parts/_main_userxp.part.js
@@ -5,6 +5,11 @@ var czrapp = czrapp || {};
 *************************************************/
 (function($, czrapp) {
   var _methods =  {
+    init : function() {
+      this.timer     = 0;
+      this.increment = 1;//used to wait a little bit after the first user scroll actions to trigger the timer
+    },//init
+
     //SMOOTH SCROLL FOR AUTHORIZED LINK SELECTORS
     anchorSmoothScroll : function() {
       if ( ! TCParams.SmoothScroll || 'easeOutExpo' != TCParams.SmoothScroll )
@@ -47,6 +52,47 @@ var czrapp = czrapp || {};
       });
     },
 
+
+    //Event Listener
+    eventListener : function() {
+      var self = this;
+      czrapp.$_window.scroll( function() {
+        self.eventHandler( 'scroll' );
+      });
+      
+      czrapp.$_window.on( 'tc_scroll' , function() {
+        self.eventHandler( 'tc_scroll' );
+      });
+    },
+
+    //Event Handler
+    eventHandler : function ( evt ) {
+      var self = this;
+      switch ( evt ) {
+        case 'scroll' :    
+          //use a timer
+          if ( this.timer) {
+            this.increment++;
+            clearTimeout(self.timer);
+          }
+
+          if ( 1 == TCParams.timerOnScrollAllBrowsers ) {
+            this.timer = setTimeout( function() {
+              czrapp.$_window.trigger('tc_scroll');
+            }, self.increment > 5 ? 50 : 0 );
+          } else if ( czrapp.$_body.hasClass('ie') ) {
+            this.timer = setTimeout( function() {
+              czrapp.$_window.trigger('tc_scroll');
+            }, self.increment > 5 ? 50 : 0 );
+          }
+        break;    
+      
+        case 'tc_scroll' :
+          if ( $('.tc-btt-wrapper').length > 0 )  
+            this.bttArrowRender();
+        break;
+      }
+    },//eventHandler
 
     //VARIOUS HOVER ACTION
     widgetsHoverActions : function() {
@@ -212,7 +258,15 @@ var czrapp = czrapp || {};
             return false;
         });//.on()
       });//.each()
-    }
+    },
+
+    bttArrowRender : function () {
+      if ( czrapp.$_window.scrollTop() > 100 )
+        $('.tc-btt-wrapper').addClass('show');
+      else
+        $('.tc-btt-wrapper').removeClass('show');
+    }//bttArrowRender
+
   };//_methods{}
 
   czrapp.methods.Czr_UserExperience = {};

--- a/inc/assets/js/parts/_main_xfire.part.js
+++ b/inc/assets/js/parts/_main_xfire.part.js
@@ -8,7 +8,7 @@ jQuery(function ($) {
     BrowserDetect : [],
     Czr_Plugins : ['centerImagesWithDelay', 'imgSmartLoad' , 'dropCaps', 'extLinks' , 'fancyBox'],
     Czr_Slider : ['fireSliders', 'manageHoverClass', 'centerSliderArrows', 'addSwipeSupport', 'sliderTriggerSimpleLoad'],
-    Czr_UserExperience : ['anchorSmoothScroll', 'backToTop', 'widgetsHoverActions', 'attachmentsFadeEffect', 'clickableCommentButton', 'dynSidebarReorder', 'dropdownMenuEventsHandler' ],
+    Czr_UserExperience : ['eventListener', 'anchorSmoothScroll', 'backToTop', 'widgetsHoverActions', 'attachmentsFadeEffect', 'clickableCommentButton', 'dynSidebarReorder', 'dropdownMenuEventsHandler' ],
     Czr_StickyHeader : ['stickyHeaderEventListener', 'triggerStickyHeaderLoad' ]
   };
   czrapp.cacheProp().loadCzr(toLoad);


### PR DESCRIPTION
Back to top arrow js code was missing in the new front js, as reported in #194 
This PR reintroduces it.
I also thought to move the window's scroll event listening/handling in the user experience jq plugin, since both btt-arrow and sticky header share the same code.
Dunno what you think or whether you want to treat it in a different way, anyway.. 
bug fixed :P 