### PR TITLE
Fix: re-introduce btt-arrow handling in new front js

### DIFF
--- a/inc/assets/js/parts/_main_sticky_header.part.js
+++ b/inc/assets/js/parts/_main_sticky_header.part.js
@@ -70,11 +70,11 @@ var czrapp = czrapp || {};
           }
 
           if ( 1 == TCParams.timerOnScrollAllBrowsers ) {
-            timer = setTimeout( function() {
+            this.timer = setTimeout( function() {
               self._sticky_header_scrolling_actions();
             }, self.increment > 5 ? 50 : 0 );
           } else if ( czrapp.$_body.hasClass('ie') ) {
-            timer = setTimeout( function() {
+            this.timer = setTimeout( function() {
               self._sticky_header_scrolling_actions();
             }, self.increment > 5 ? 50 : 0 );
           }

--- a/inc/assets/js/parts/_main_userxp.part.js
+++ b/inc/assets/js/parts/_main_userxp.part.js
@@ -5,6 +5,53 @@ var czrapp = czrapp || {};
 *************************************************/
 (function($, czrapp) {
   var _methods =  {
+    init : function() {
+       this.timer = 0;
+       this.increment = 1;//used to wait a little bit after the first user scroll actions to trigger the timer
+    },//init  
+
+    
+    //Event Listener
+    eventListener : function() {
+      var self = this;
+
+      czrapp.$_window.scroll( function() {
+        self.eventHandler( 'scroll' );
+      });
+
+    },//eventListener
+
+    
+    //Event Handler
+    eventHandler : function ( evt ) {
+      var self = this;
+      
+      switch ( evt ) {
+        case 'scroll' : 
+          //react to window scroll only when we have the btt-arrow element
+          //I do this here 'cause I plan to pass the btt-arrow option as postMessage in customize
+          if ( 0 === $('.tc-btt-wrapper').length )  
+            return;
+
+          //use a timer
+          if ( this.timer) {
+            this.increment++;
+            clearTimeout(self.timer);
+          }
+          if ( 1 == TCParams.timerOnScrollAllBrowsers ) {
+            this.timer = setTimeout( function() {
+              self.bttArrowVisibility();
+            }, self.increment > 5 ? 50 : 0 );
+          } else if ( czrapp.$_body.hasClass('ie') ) {
+            this.timer = setTimeout( function() {
+              self.bttArrowVisibility();
+            }, self.increment > 5 ? 50 : 0 );
+          }
+        break;
+      }
+    },//eventHandler
+
+    
     //SMOOTH SCROLL FOR AUTHORIZED LINK SELECTORS
     anchorSmoothScroll : function() {
       if ( ! TCParams.SmoothScroll || 'easeOutExpo' != TCParams.SmoothScroll )
@@ -26,6 +73,15 @@ var czrapp = czrapp || {};
         return false;
       });//click
     },
+
+    //Btt arrow visibility
+    bttArrowVisibility : function () {
+      if ( czrapp.$_window.scrollTop() > 100 )
+        $('.tc-btt-wrapper').addClass('show');
+      else
+        $('.tc-btt-wrapper').removeClass('show');
+    },//bttArrowVisibility
+
 
 
     //BACK TO TOP

--- a/inc/assets/js/parts/_main_xfire.part.js
+++ b/inc/assets/js/parts/_main_xfire.part.js
@@ -8,7 +8,7 @@ jQuery(function ($) {
     BrowserDetect : [],
     Czr_Plugins : ['centerImagesWithDelay', 'imgSmartLoad' , 'dropCaps', 'extLinks' , 'fancyBox'],
     Czr_Slider : ['fireSliders', 'manageHoverClass', 'centerSliderArrows', 'addSwipeSupport', 'sliderTriggerSimpleLoad'],
-    Czr_UserExperience : ['anchorSmoothScroll', 'backToTop', 'widgetsHoverActions', 'attachmentsFadeEffect', 'clickableCommentButton', 'dynSidebarReorder', 'dropdownMenuEventsHandler' ],
+    Czr_UserExperience : ['eventListener','anchorSmoothScroll', 'backToTop', 'widgetsHoverActions', 'attachmentsFadeEffect', 'clickableCommentButton', 'dynSidebarReorder', 'dropdownMenuEventsHandler' ],
     Czr_StickyHeader : ['stickyHeaderEventListener', 'triggerStickyHeaderLoad' ]
   };
   czrapp.cacheProp().loadCzr(toLoad);


### PR DESCRIPTION
Back to top arrow js code was missing in the new front js, as reported in #194
This PR reintroduces it.

p.s.
plus, fix small bug in the sticky-header plugin, properly use of object attribute this.timer