### PR TITLE
Fix: better check on whether display or not attachment content

### DIFF
--- a/inc/parts/class-content-attachment.php
+++ b/inc/parts/class-content-attachment.php
@@ -31,7 +31,7 @@ if ( ! class_exists( 'TC_attachment' ) ) :
         function tc_attachment_content() {
             //check conditional tags
             global $post;
-            if (isset($post) && 'attachment' != $post -> post_type || !is_singular() )
+            if ( ! isset($post) || empty($post) || 'attachment' != $post -> post_type || !is_singular() )
                 return;
 
             ob_start();


### PR DESCRIPTION
I've found that there could be one case in which the theme tries to display the attachment anyways.
It happens, because of some plugin, when $post isn't set but is_singular() returns true .
Since the $post is still not set the only thing, in that case, that will be displayed is:
1) the title, if any, because of the __before_content action hook fired
2) the image navigation

Both unneeded :D

This will fix it.