### PR TITLE
Fix: Use the global post variable in place of get_post for wp backwar…

### DIFF
--- a/inc/class-fire-init.php
+++ b/inc/class-fire-init.php
@@ -694,7 +694,7 @@ if ( ! class_exists( 'TC_init' ) ) :
           array_push( $_classes, esc_attr( TC_utils::$inst->tc_opt( 'tc_dropcap_design' ) ) );
 
         //adds the layout
-        $_layout = TC_utils::tc_get_layout( get_the_ID() , 'sidebar' );
+        $_layout = TC_utils::tc_get_layout( TC_utils::tc_id() , 'sidebar' );
         if ( in_array( $_layout, array('b', 'l', 'r' , 'f') ) ) {
           array_push( $_classes, sprintf( 'tc-%s-sidebar',
             'f' == $_layout ? 'no' : $_layout

--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -325,12 +325,12 @@ if ( ! class_exists( 'TC_utils' ) ) :
       * @since Customizr 1.0
       */
       public static function tc_id()  {
-        global $wp_version;
-        if ( in_the_loop() || version_compare( $wp_version, '3.4.1', '<=' ) ) {
+        if ( in_the_loop() ) {
           $tc_id            = get_the_ID();
         } else {
+          global $post;  
           $queried_object   = get_queried_object();
-          $tc_id            = ! is_null( get_post() ) ? get_the_ID() : null;
+          $tc_id            = ( ! empty ( $post ) && isset($post -> ID) ) ? $post -> ID : null;
           $tc_id            = ( isset ($queried_object -> ID) ) ? $queried_object -> ID : $tc_id;
         }
         return ( is_404() || is_search() || is_archive() ) ? null : $tc_id;


### PR DESCRIPTION
…d compatibility

Because of this:
https://wordpress.org/support/topic/warning-message-on-redirect-link?replies=1

Looks like get_post() requires a param at least on 3.4.2 too, so why don't we use the global $post ?
What do you think about that?