### PR TITLE
Fix: slider front and backend improvements

### DIFF
--- a/inc/admin/class-admin-meta_boxes.php
+++ b/inc/admin/class-admin-meta_boxes.php
@@ -236,7 +236,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
               <input name="<?php echo $post_slider_check_id; ?>" type="hidden" value="0"/>
               <input name="<?php echo $post_slider_check_id ?>" id="<?php echo $post_slider_check_id; ?>" type="checkbox" class="iphonecheck" value="1" <?php checked( $post_slider_checked, $current = true, $echo = true ) ?>/>
             </div>
-            <div id="post_slider_infos">
+            <div id="slider-fields-box">
               <?php do_action( '__post_slider_infos' , $post -> ID ); ?>
             </div>
           <?php
@@ -252,7 +252,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
      * @package Customizr
      * @since Customizr 2.0
      */
-      function tc_get_post_slider_infos( $postid) {
+      function tc_get_post_slider_infos( $postid ) {
           //check value is ajax saved ?
           $post_slider_check_value   = esc_attr(get_post_meta( $postid, $key = 'post_slider_check_key' , $single = true ));
 
@@ -284,13 +284,13 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
 
 
           ?>
-          <?php if( $post_slider_check_value == true) : ?>
+          <?php if( $post_slider_check_value == true ): ?>
               <div class="meta-box-item-title">
                 <h4><?php _e("Choose a slider", 'customizr' ); ?></h4>
               </div>
               <?php if (isset($sliders) && !empty( $sliders)) : ?>
                 <div class="meta-box-item-content">
-                  <span class="spinner" style="float: left;"></span>
+                  <span class="spinner" style="float: left;visibility:visible;display: none;"></span>
                   <select name="<?php echo $post_slider_id; ?>" id="<?php echo $post_slider_id; ?>">
                     <?php //no link option ?>
                     <option value="" <?php selected( $current_post_slider, $current = null, $echo = true ) ?>> <?php _e( '&mdash; Select a slider &mdash; ' , 'customizr' ); ?></option>
@@ -507,7 +507,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
               <input name="<?php echo $slider_check_id; ?>" type="hidden" value="0"/>
               <input name="<?php echo $slider_check_id ?>" id="<?php echo $slider_check_id; ?>" type="checkbox" class="iphonecheck" value="1" <?php checked( $slider_checked, $current = true, $echo = true ) ?>/>
             </div>
-           <div id="tc_slider_list">
+           <div id="slider-fields-box">
              <?php do_action( '__attachment_slider_infos' , $post -> ID); ?>
            </div>
           <?php
@@ -525,7 +525,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
        * @package Customizr
        * @since Customizr 2.0
        */
-        function tc_get_attachment_slider_infos( $postid) {
+        function tc_get_attachment_slider_infos( $postid ) {
           //check value is ajax saved ?
           $slider_check_value     = esc_attr(get_post_meta( $postid, $key = 'slider_check_key' , $single = true ));
 
@@ -610,6 +610,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
           $post_types     = get_post_types(array( 'public' => true));
           $excludes       = array( 'attachment' );
 
+
           foreach ( $post_types as $t) {
               if (!in_array( $t, $excludes)) {
                //get the posts a tab of types
@@ -622,9 +623,21 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                 );
               }
             };
+ 
+          //custom link field setup
+          $custom_link_id    = 'slide_custom_link_field';
+          $custom_link_value = esc_url( get_post_meta( $postid, $key = 'slide_custom_link_key', $single = true ) );
+
+          //link target setup
+          $link_target_id    = 'slide_link_target_field';
+          $link_target_value = esc_attr( get_post_meta( $postid, $key = 'slide_link_target_key', $single = true ) ) ;
+
+          //link whole slide setup
+          $link_whole_slide_id    = 'slide_link_whole_slide_field';
+          $link_whole_slide_value = esc_attr( get_post_meta( $postid, $key = 'slide_link_whole_slide_key', $single = true ) ) ;
 
           //display fields if slider button is checked
-          if ( $slider_check_value == 1)  {
+          if ( $slider_check_value == true )  {
              ?>
             <div class="meta-box-item-title">
                 <h4><?php _e( 'Title text (80 car. max length)' , 'customizr' ); ?></h4>
@@ -670,6 +683,26 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                 </select><br />
             </div>
             <div class="meta-box-item-title">
+                <h4><?php _e("or a custom link (leave this empty if you selected a page or post above)", 'customizr' ); ?></h4>
+            </div>
+            <div class="meta-box-item-content">
+                <input class="widefat" name="<?php echo $custom_link_id; ?>" id="<?php echo $custom_link_id; ?>" value="<?php echo $custom_link_value; ?>" style="width:50%">
+            </div>
+            <div class="meta-box-item-title">
+                <h4><?php _e("Open link in a new page/tab", 'customizr' );  ?></h4>
+            </div>
+            <div class="meta-box-item-content">
+                <input name="<?php echo $link_target_id; ?>" type="hidden" value="0"/>
+                <input name="<?php echo $link_target_id; ?>" id="<?php echo $link_target_id; ?>" type="checkbox" class="iphonecheck" value="1" <?php checked( $link_target_value, $current = true, $echo = true ) ?>/>
+            </div>
+            <div class="meta-box-item-title">
+                <h4><?php _e("Link the whole slide", 'customizr' );  ?></h4>
+            </div>
+            <div class="meta-box-item-content">
+                <input name="<?php echo $link_whole_slide_id; ?>" type="hidden" value="0"/>
+                <input name="<?php echo $link_whole_slide_id; ?>" id="<?php echo $link_whole_slide_id; ?>" type="checkbox" class="iphonecheck" value="1" <?php checked( $link_whole_slide_value, $current = true, $echo = true ) ?>/>
+            </div>
+            <div class="meta-box-item-title">
               <h4><?php _e("Choose a slider", 'customizr' ); ?></h4>
             </div>
             <?php if (!empty( $sliders)) : ?>
@@ -692,7 +725,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                   </select>
                   <input name="<?php echo $slider_id  ?>" id="<?php echo $slider_id ?>" value=""/>
                   <span class="button-primary" id="tc_create_slider"><?php _e( 'Add a slider' , 'customizr' ) ?></span>
-                  <span class="spinner" style="float: left;"></span>
+                  <span class="spinner" style="float: left;visibility:visible;display: none;"></span>
                   <?php if (isset( $current_post_slides)) : ?>
                       <p style="text-align:right"><a href="#TB_inline?width=350&height=100&inlineId=slider-warning-message" class="thickbox"><?php _e( 'Delete this slider' , 'customizr' ) ?></a></p>
                       <div id="slider-warning-message" style="display:none;">
@@ -721,7 +754,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                    <p class="description"> <?php _e("You haven't create any slider yet. Write a slider name and click on the button to add you first slider.", "customizr" ) ?><br/>
                     <input name="<?php echo $slider_id  ?>" id="<?php echo $slider_id ?>" value=""/>
                     <span class="button-primary" id="tc_create_slider"><?php _e( 'Add a slider' , 'customizr' ) ?></span>
-                    <span class="spinner" style="float: left"></span>
+                    <span class="spinner" style="float: left; diplay:none;"></span>
                    </p>
                     <br />
                 </div>
@@ -767,12 +800,15 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
 
           //set up the fields array
           $tc_slider_fields = array(
-              'slide_title_field'           => 'slide_title_key' ,
-              'slide_text_field'            => 'slide_text_key' ,
-              'slide_color_field'           => 'slide_color_key' ,
-              'slide_button_field'          => 'slide_button_key' ,
-              'slide_link_field'            => 'slide_link_key'
-              );
+              'slide_title_field'             => 'slide_title_key' ,
+              'slide_text_field'              => 'slide_text_key' ,
+              'slide_color_field'             => 'slide_color_key' ,
+              'slide_button_field'            => 'slide_button_key' ,
+              'slide_link_field'              => 'slide_link_key' ,
+              'slide_custom_link_field'       => 'slide_custom_link_key',
+              'slide_link_target_field'       => 'slide_link_target_key',
+              'slide_link_whole_slide_field'  => 'slide_link_whole_slide_key'
+          );
 
           //if saving in a custom table, get post_ID
           if ( $post_id == null)
@@ -784,17 +820,25 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                   $mydata = sanitize_text_field( $_POST[$tcid] );
                     switch ( $tckey) {
                       //different sanitizations
-
                       case 'slide_text_key':
                           $default_text_length = apply_filters( 'tc_slide_text_length', 250 );
                           if (strlen( $mydata) > $default_text_length) {
-                          $mydata = substr( $mydata,0,strpos( $mydata, ' ' ,$default_text_length));
-                          $mydata = esc_html( $mydata) . ' ...';
+                            $mydata = substr( $mydata,0,strpos( $mydata, ' ' ,$default_text_length));
+                            $mydata = esc_html( $mydata) . ' ...';
                           }
                           else {
                             $mydata = esc_html( $mydata);
                           }
                         break;
+                      
+                      case 'slide_custom_link_key':
+                          $mydata = esc_url( $_POST[$tcid] );
+                      break;
+
+                      case 'slide_link_target_key';
+                      case 'slide_link_whole_slide_key':
+                          $mydata = esc_attr( $mydata );
+                      break;
 
                       default://for button, color, title and post link field (actually not a link but an id)
                           $default_title_length = apply_filters( 'tc_slide_title_length', 80 );
@@ -849,7 +893,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                           <th scope="col"><?php _e( 'Title' , 'customizr' ) ?></th>
                           <th scope="col" style="width: 35%"><?php _e( 'Slide Text' , 'customizr' ) ?></th>
                           <th scope="col"><?php _e( 'Button Text' , 'customizr' ) ?></th>
-                          <th scope="col"><?php _e( 'Button Link' , 'customizr' ) ?></th>
+                          <th scope="col"><?php _e( 'Link' , 'customizr' ) ?></th>
                           <th scope="col"><?php _e( 'Edit' , 'customizr' ) ?></th>
                         </tr>
                       </thead>
@@ -877,6 +921,8 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                         $text                   = esc_html(get_post_meta( $id, $key = 'slide_text_key' , $single = true ));
                         $text_color             = esc_attr(get_post_meta( $id, $key = 'slide_color_key' , $single = true ));
                         $button_text            = esc_attr(get_post_meta( $id, $key = 'slide_button_key' , $single = true ));
+                        $link                   = esc_url(get_post_meta( $id, $key = 'slide_custom_link_key' , $single = true ));
+
                         $button_link            = esc_attr(get_post_meta( $id, $key = 'slide_link_key' , $single = true ));
 
                         //check if $text_color is set and create an html style attribute
@@ -912,7 +958,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                           </td>
                            <td style="vertical-align:middle" class="">
                               <?php if( $button_link != null) : ?>
-                                <p class="btn btn-large btn-primary" href="<?php echo get_permalink( $button_link); ?>"><?php echo get_the_title( $button_link); ?></p>
+                                <p class="btn btn-large btn-primary" href="<?php echo $link ? $link : get_permalink( $button_link); ?>"><?php echo $link ? $link : get_the_title( $button_link); ?></p>
                               <?php endif; ?>
                           </td>
                            <td style="vertical-align:middle" class="">
@@ -964,7 +1010,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
             else {
                 $post_ID = $_POST['tc_post_id'];
             }
-
+            
             //OPTION FIELDS
             //get options and some useful $_POST vars
             $tc_options                 = get_option( 'tc_theme_options' );
@@ -1163,11 +1209,6 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                 'post_slider_check_field'     => 'post_slider_check_key' ,
                 //attachments
                 'slider_check_field'          => 'slider_check_key' ,
-                'slide_title_field'           => 'slide_title_key' ,
-                'slide_text_field'            => 'slide_text_key' ,
-                'slide_color_field'           => 'slide_color_key' ,
-                'slide_button_field'          => 'slide_button_key' ,
-                'slide_link_field'            => 'slide_link_key'
                 );
 
                 //sanitize user input by looping on the fields
@@ -1219,44 +1260,13 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                               }//endif;
 
                           break;
-
-                          case 'slide_text_key':
-                          //check if we add this attachment to a slider for the first time : do we have custom fields defined in DB and are the input fields existing in the DOM (sent by Ajax)?
-
-                                $mydata = sanitize_text_field( $_POST[$tcid] );
-                                if (strlen( $mydata) > 250) {
-                                $mydata = substr( $mydata,0,strpos( $mydata, ' ' ,250));
-                                $mydata = esc_html( $mydata) . ' ...';
-                                }
-                                else {
-                                  $mydata = esc_html( $mydata);
-                                }
-                                 //write in DB
-                                add_post_meta( $post_ID, $tckey, $mydata, true) or
-                                update_post_meta( $post_ID, $tckey , $mydata);
-
-                            break;
-
-                          default://for button, color, title and post link field (actually not a link but an id)
-                          //check if we add this attachment to a slider for the first time : do we have custom fields defined in DB and are the input fields existing in the DOM (sent by Ajax)?
-
-                               $mydata = sanitize_text_field( $_POST[$tcid] );
-                               $default_button_length = apply_filters( 'tc_slide_button_length', 80 );
-                               if (strlen( $mydata) > $default_button_length) {
-                                $mydata = substr( $mydata,0,strpos( $mydata, ' ' ,$default_button_length));
-                                $mydata = esc_attr( $mydata) . ' ...';
-                                }
-                                else {
-                                  $mydata = esc_attr( $mydata);
-                                }
-                                //write in DB
-                                add_post_meta( $post_ID, $tckey, $mydata, true) or
-                                update_post_meta( $post_ID, $tckey , $mydata);
-
-                            break;
                         }//end switchendif;
                     }//end if ( isset( $_POST[$tcid])) {
                 }//end foreach
+                //attachments
+                if( $tc_post_type == 'attachment' )
+                  $this -> tc_slide_save( $post_ID );
+                
             }//function
 
 
@@ -1284,6 +1294,7 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
       if ( ! wp_verify_nonce( $nonce, 'tc-slider-check-nonce' ) ) {
         die();
       }
+
         Try{
         //get the post_id with the hidden input field
         $tc_post_id         = $_POST['tc_post_id'];
@@ -1295,10 +1306,10 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
         //we use the post_slider var defined in tc_ajax_slider.js
         if ( isset( $_POST['tc_post_type'])) {
           if( $_POST['tc_post_type'] == 'post' ) {
-            $this -> tc_get_post_slider_infos( $tc_post_id);
+            $this -> tc_get_post_slider_infos( $tc_post_id );
           }
           else {
-            $this -> tc_get_attachment_slider_infos( $tc_post_id);
+            $this -> tc_get_attachment_slider_infos( $tc_post_id );
           }
         }
         //echo $_POST['slider_id'];
@@ -1320,13 +1331,19 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
        */
         function tc_slider_admin_scripts( $hook) {
         global $post;
+        
+        $_min_version = ( defined('WP_DEBUG') && true === WP_DEBUG ) ? '' : '.min';
         //load scripts only for creating and editing slides options in pages and posts
         if( ( 'media.php'  == $hook)) {
             wp_enqueue_script( 'jquery-ui-sortable' );
         }
         if( ( 'post-new.php' == $hook || 'post.php' == $hook || 'media.php' == $hook) )  {
             //ajax refresh for slider options
-            wp_enqueue_script( 'tc_ajax_slider' , TC_BASE_URL.'inc/admin/js/tc_ajax_slider.min.js' , array( 'jquery' ), true );
+            wp_enqueue_script( 'tc_ajax_slider' , 
+                sprintf('%1$sinc/admin/js/tc_ajax_slider%2$s.js' , TC_BASE_URL, $_min_version ),
+                array( 'jquery' ), 
+                true 
+            );
 
             // Tips to declare javascript variables http://www.garyc40.com/2010/03/5-tips-for-using-ajax-in-wordpress/#bad-ways
             wp_localize_script( 'tc_ajax_slider' , 'SliderAjax' , array(
@@ -1342,15 +1359,24 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
             );
 
             //iphone like button style and script
-            wp_enqueue_style( 'iphonecheckcss' , TC_BASE_URL.'inc/admin/css/iphonecheck.css' );
-            wp_enqueue_script( 'iphonecheck' , TC_BASE_URL.'inc/admin/js/jquery.iphonecheck.js' );
+            wp_enqueue_style( 'iphonecheckcss' ,
+                sprintf('%1$sinc/admin/css/iphonecheck%2$s.css' , TC_BASE_URL, $_min_version )
+            );
+            wp_enqueue_script( 'iphonecheck' , 
+
+                sprintf('%1$sinc/admin/js/jquery.iphonecheck%2$s.js' , TC_BASE_URL, $_min_version ),
+                array('jquery'),
+                true
+            );
 
             //thickbox
             wp_admin_css( 'thickbox' );
             add_thickbox();
 
             //sortable stuffs
-            wp_enqueue_style( 'sortablecss' , TC_BASE_URL.'inc/admin/css/tc_sortable.css' );
+            wp_enqueue_style( 'sortablecss' , 
+                sprintf('%1$sinc/admin/css/tc_sortable%2$s.css' , TC_BASE_URL, $_min_version )
+            );
 
             //wp built-in color picker style and script
            //Access the global $wp_version variable to see which version of WordPress is installed.
@@ -1362,7 +1388,11 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                 wp_enqueue_style( 'wp-color-picker' );
                 wp_enqueue_script( 'wp-color-picker' );
                  // load the minified version of custom script
-              wp_enqueue_script( 'cp_demo-custom' , TC_BASE_URL.'inc/admin/js/color-picker.js' , array( 'jquery' , 'wp-color-picker' ), true );
+                wp_enqueue_script( 'cp_demo-custom' ,
+                    sprintf('%1$sinc/admin/js/color-picker%2$s.js' , TC_BASE_URL, $_min_version ),
+                    array( 'jquery' , 'wp-color-picker' ), 
+                    true 
+                );
             }
             //If the WordPress version is less than 3.5 load the older farbtasic color picker.
             else {
@@ -1370,7 +1400,11 @@ if ( ! class_exists( 'TC_meta_boxes' ) ) :
                 wp_enqueue_style( 'farbtastic' );
                 wp_enqueue_script( 'farbtastic' );
                 // load the minified version of custom script
-              wp_enqueue_script( 'cp_demo-custom' , TC_BASE_URL.'inc/admin/js/color-picker.js' , array( 'jquery' , 'farbtastic' ), true );
+                wp_enqueue_script( 'cp_demo-custom' , 
+                    sprintf('%1$sinc/admin/js/color-picker%2$s.js' , TC_BASE_URL, $_min_version ),
+                    array( 'jquery' , 'farbtastic' ), 
+                    true 
+                );
             }
         }//end post type hook check
       }

--- a/inc/admin/js/tc_ajax_slider.js
+++ b/inc/admin/js/tc_ajax_slider.js
@@ -4,324 +4,199 @@
  * @package Customizr
  * @since Customizr 1.0
  */
-jQuery(document).ready(function(){
-      jQuery( 'input#slider_check_field, select#post_slider_field' ).live("change",function(){
-        jQuery( '#tc_slider_list .spinner' ).show();
-        //check if we are in the post/page screen and return a var
-        var tc_post_type = 'attachment';
-        if(jQuery( 'input#post_slider_check_field' ).length) {
-          tc_post_type = 'post';
+var CzrSlider;
+( function($) {
+  
+  "use strict";
+  $( function(){
+    CzrSlider = function() {
+        //attribute valorization
+        this.$body                    = $('body');
+        this._action                  = 'slider_action';
+        this._nonce                   = SliderAjax.SliderCheckNonce;
+        
+        this.$_slider_section_box     = $('#slider_sectionid');
+        this.$_slider_fields_box      = $('#slider-fields-box');
+        this.$_tc_post_id             = $('input#tc_post_id');
+
+        //context: attachment or post?
+        this._check_field             = 'slider_check_field';
+        this._context                 = 'attachment'
+        if ( $('input#post_slider_check_field').length > 0 ) {
+          this._check_field           = 'post_slider_check_field'
+          this._context               = 'post'
         }
-        //get checked value
-        slider_check_field = 0;
-        if (jQuery( 'input#slider_check_field' ).is(":checked"))
-            {
-              slider_check_field = 1;
-            }
-        jQuery.post(
-           ajaxurl,
-           {
-              //ADD vars to $_POST
-              'action'              :'slider_action' ,
-              //get the post_id with an hidden input field
-              'tc_post_id'          : jQuery( 'input#tc_post_id' ).val(),
-              //add the check current state and inputs
-              'slider_check_field'  : slider_check_field,
-              'slide_title_field'   : jQuery( 'input#slide_title_field' ).val(),
-              'slide_text_field'    : jQuery( 'textarea#slide_text_field' ).val(),
-              'slide_color_field'   : jQuery( 'input#slide_color_field' ).val(),
-              'slide_button_field'  : jQuery( 'input#slide_button_field' ).val(),
-              'slide_link_field'    : jQuery( 'select#slide_link_field' ).val(),
-              'new_slider_name'     : jQuery( 'input#slider_field' ).val(),
-              'post_slider_name'    : jQuery( 'select#post_slider_field' ).val(),
-              // send the nonce along with the request
-              'SliderCheckNonce'    : SliderAjax.SliderCheckNonce,
-              //post var if we are in a post/page screen
-              'tc_post_type'         : tc_post_type
-           },
-           function(response){
-              //alert( 'The server responded: ' + response);
-              jQuery("#tc_slider_list").empty();
-              jQuery("#tc_slider_list").append(response);
 
-              //reactivate the color picker
-              if( typeof jQuery.wp === 'object' && typeof jQuery.wp.wpColorPicker === 'function' ){
-                  jQuery( '#slide_color_field' ).wpColorPicker();
-              }
-              else {
-                  //We use farbtastic if the WordPress color picker widget doesn't exist
-                  if( jQuery( '#slide_color_field' ).length ) {
-                    jQuery( '#colorpicker' ).farbtastic( '#slide_color_field' );
-                  }
-              }
-              //reactivate sortable
-              jQuery( '#sortable' ).sortable({
-              placeholder: "ui-state-highlight",
-              update: function(event, ui) {
-                  var newOrder = jQuery(this).sortable( 'toArray' ).toString();
-                  jQuery.post(
-                     ajaxurl,
-                     {
-                        //ADD vars to $_POST
-                        'action':'slider_action' ,
-                        //get the post_id with an hidden input field
-                        'tc_post_id': jQuery( 'input#tc_post_id' ).val(),
-                         // send the nonce along with the request
-                        'SliderCheckNonce' : SliderAjax.SliderCheckNonce,
-                        //position array
-                        'newOrder':newOrder,
-                        //current post slider
-                        'currentpostslider':jQuery( 'select#post_slider_field' ).val()
-                     },
-                     function(response){
-                        //alert( 'The server responded: ' +  response);
-                         slider_update = jQuery( '<div/>' ).addClass( 'updated' )
-                        .css( 'opacity' ,0)
-                        .html( '<div class="message">Slider updated</div>' )
-                        .appendTo( '#update-status' );
-                        slider_update.animate({opacity:0.9}, function(){
-                        slider_update.delay(1200).fadeOut(function()
-                          {
-                            slider_update.remove();
-                          });
-                        });
-                     }
-                  );
-                }
-            });
-           jQuery( '#sortable' ).disableSelection();
-           jQuery( '#tc_slider_list .spinner' ).hide();
-           }//end of response
-        );
-      });
+        this.$_slider_check_field     = $('input#' + this._check_field);  
+        this._color_picker_on         = 'post' == this.$_context ? false : true;
+ 
+        if ( this._color_picker_on )
+          this._color_picker_func = ( typeof jQuery.wp === 'object' && typeof jQuery.wp.wpColorPicker === 'function' ) ? 'wpColorPicker' : 'farbtastic' ;    
 
+        // initial data to send over $_POST, the acual sent data will be an extension of this
+        this._data                   = {
+              'action'             : this._action,
+              'tc_post_id'         : this.$_tc_post_id.val(),
+              'SliderCheckNonce'   : this._nonce,
+              'tc_post_type'       : this._context
+        };
 
-    jQuery( '#tc_create_slider' ).live("click",function(){
-        jQuery( '#tc_slider_list .spinner' ).show();
-        //check if we are in the post/page screen and return a var
-        var tc_post_type = 'attachment';
-        if(jQuery( 'input#post_slider_check_field' ).length) {
-          tc_post_type = 'post';
-        }
-        //get checked value
-        var slider_check_field = 0;
-        if (jQuery( 'input#slider_check_field' ).is(":checked"))
-            {
-              slider_check_field = 1;
-            }
-        jQuery.post(
-           ajaxurl,
-           {
-             //ADD vars to $_POST
-              'action'              :'slider_action' ,
-              //get the post_id with an hidden input field
-              'tc_post_id'          : jQuery( 'input#tc_post_id' ).val(),
-              //add the check current state and inputs
-              'slider_check_field'  : slider_check_field,
-              'slide_title_field'   : jQuery( 'input#slide_title_field' ).val(),
-              'slide_text_field'    : jQuery( 'textarea#slide_text_field' ).val(),
-              'slide_color_field'   : jQuery( 'input#slide_color_field' ).val(),
-              'slide_button_field'  : jQuery( 'input#slide_button_field' ).val(),
-              'slide_link_field'    : jQuery( 'select#slide_link_field' ).val(),
-              'new_slider_name'     : jQuery( 'input#slider_field' ).val(),
-              'post_slider_name'    : jQuery( 'select#post_slider_field' ).val(),
-              // send the nonce along with the request
-              'SliderCheckNonce'    : SliderAjax.SliderCheckNonce,
-              //post var if we are in a post/page screen
-              'tc_post_type'         : tc_post_type
-           },
-           function(response){
-              //alert( 'The server responded: ' + response);
-              jQuery("#tc_slider_list").empty();
-              jQuery("#tc_slider_list").append(response);
+        //event connecting
+        this.eventListeners();
+        //init sortable, other ext plugins already initialized
+        this._init_sortable();
+    };
 
-              //reactivate the color picker
-              if( typeof jQuery.wp === 'object' && typeof jQuery.wp.wpColorPicker === 'function' ){
-                  jQuery( '#slide_color_field' ).wpColorPicker();
-              }
-              else {
-                  //We use farbtastic if the WordPress color picker widget doesn't exist
-                  if( jQuery( '#slide_color_field' ).length ) {
-                    jQuery( '#colorpicker' ).farbtastic( '#slide_color_field' );
-                  }
-              }
-              //reactivate sortable
-              jQuery( '#sortable' ).sortable({
-                placeholder: "ui-state-highlight"
-              });
-              jQuery( '#tc_slider_list .spinner' ).hide();
-           }
-        );
-      });
+    $.extend( CzrSlider.prototype, {
+      eventListeners : function(){
+        var self = this;
 
+        // elements events
+        
+        //enable slider
+        this.$body.on('change', 'input#' + this._check_field, function(){
+           self.ajax( self._build_data('enable') );
 
-       jQuery( '#sortable' ).sortable({
-            placeholder: "ui-state-highlight",
-            update: function(event, ui) {
-                var newOrder = jQuery(this).sortable( 'toArray' ).toString();
-                jQuery.post(
-                   ajaxurl,
-                   {
-                      //ADD vars to $_POST
-                      'action':'slider_action' ,
-                      //get the post_id with an hidden input field
-                      'tc_post_id': jQuery( 'input#tc_post_id' ).val(),
-                       // send the nonce along with the request
-                      'SliderCheckNonce' : SliderAjax.SliderCheckNonce,
-                      //position array
-                      'newOrder':newOrder,
-                      //current post slider
-                      'currentpostslider':jQuery( 'select#post_slider_field' ).val()
-                   },
-                   function(response){
-                      //alert( 'The server responded: ' +  response);
-                      slider_update = jQuery( '<div/>' ).addClass( 'updated' )
-                      .css( 'opacity' ,0)
-                      .html( '<div class="message">Slider updated</div>' )
-                      .appendTo( '#update-status' );
-                      slider_update.animate({opacity:0.9}, function(){
-                      slider_update.delay(1200).fadeOut(function()
-                        {
-                          slider_update.remove();
-                        });
-                      });
-                   }
-                );
-            }
+        //select different slider
+        }).on( 'change', 'select#post_slider_field', function(){
+           self.ajax( self._build_data('select_slider') ); 
+
+        //sort slides
+        }).on( 'sortupdate', '#slider_sectionid #sortable',function(event, ui) { 
+           self.ajax( self._build_data('reorder_slides'), '_reorder_slides_response' ); 
+
+        //create new slider
+        }).on('click', '#tc_create_slider', function(){
+           self.ajax( self._build_data('new_slider') ); 
+
+        //delete slider
+        }).on('click', '#delete-slider', function(){
+           self.ajax( self._build_data('delete_slider') ); 
         });
-       jQuery( '#sortable' ).disableSelection();
 
+      },
 
-       jQuery( '#delete-slider' ).live("click",function(){
-        //checks if we are in the post/page/attachment screen and returns a var
-        var tc_post_type = 'attachment';
-        if(jQuery( 'input#post_slider_check_field' ).length) {
-          tc_post_type = 'post';
-        }
-        jQuery.post(
-           ajaxurl,
-           {
-             //ADD vars to $_POST
-              'action'              :'slider_action' ,
-              //get the post_id with an hidden input field
-              'tc_post_id'          : jQuery( 'input#tc_post_id' ).val(),
-              //add the check current state and inputs
-              'delete_slider'       : true,
-              //reset new_slider_name if needed
-              'new_slider_name'    : null,
-              //current post sider
-              'currentpostslider'   : jQuery( 'select#post_slider_field' ).val(),
-              // send the nonce along with the request
-              'SliderCheckNonce'    : SliderAjax.SliderCheckNonce,
-              //post var if we are in a post/page screen
-              'tc_post_type'         : tc_post_type
-           },
-           function(response){
-              //page/post screen case
-              if(jQuery( 'input#post_slider_check_field' ).length) {
-                jQuery("#post_slider_infos").empty();
-                jQuery("#post_slider_infos").append(response);
-              }
-              //attachment screen case
-              else {
-                jQuery("#tc_slider_list").empty();
-                jQuery("#tc_slider_list").append(response);
-              }
-              //iphone checkbox
-              jQuery( '.iphonecheck' ).iphoneStyle({ checkedLabel: 'Yes' , uncheckedLabel: 'No' });
+      ajax : function( _data, _callback ){
+        var self = this;
+        this.$_slider_fields_box.find('.spinner').show();
 
-              //reactivate the color picker
-              if( typeof jQuery.wp === 'object' && typeof jQuery.wp.wpColorPicker === 'function' ){
-                  jQuery( '#slide_color_field' ).wpColorPicker();
-              }
-              else {
-              //We use farbtastic if the WordPress color picker widget doesn't exist
-                if( jQuery( '#slide_color_field' ).length ) {
-                    jQuery( '#colorpicker' ).farbtastic( '#slide_color_field' );
-                }
-              }
-              //reactivate sortable
-              jQuery( '#sortable' ).sortable({
-                placeholder: "ui-state-highlight"
-              });
-           }
-        );
-      });
-
-      jQuery( 'input#post_slider_check_field, select#post_slider_field' ).live("change",function(){
-        jQuery( '#post_slider_infos .spinner' ).show();
-         //checks if we are in the post/page/attachment screen and returns a var
-        var tc_post_type = 'attachment';
-        if(jQuery( 'input#post_slider_check_field' ).length) {
-          tc_post_type = 'post';
-        }
-        //get checked value
-        var post_slider_check_field = 0;
-        if (jQuery( 'input#post_slider_check_field' ).is(":checked"))
-            {
-              post_slider_check_field = 1;
+        $.post(
+          ajaxurl,
+          _data,
+          function( response ){
+            if ( _callback ){
+              self[_callback]( response );
+              return;
             }
-        jQuery.post(
-           ajaxurl,
-           {
-              //ADD vars to $_POST
-              'action'                    :'slider_action' ,
-              //get the post_id with an hidden input field
-              'tc_post_id'                : jQuery( 'input#tc_post_id' ).val(),
-              //add the check current state and inputs
-              'post_slider_check_field'   : post_slider_check_field,
-              'post_slider_name'          : jQuery( 'select#post_slider_field' ).val(),
-              // send the nonce along with the request
-              'SliderCheckNonce'          : SliderAjax.SliderCheckNonce,
-              //post var if we are in a post/page screen
-              'tc_post_type'         : tc_post_type
-           },
-           function(response){
-              //alert( 'The server responded: ' + response);
-              jQuery("#post_slider_infos").empty();
-              jQuery("#post_slider_infos").append(response);
+            self._default_response( response );  
+          }
+        );//end $.post
+      },
 
-              //iphone checkbox
-              jQuery( '.iphonecheck' ).iphoneStyle({ checkedLabel: 'Yes' , uncheckedLabel: 'No' });
+      //handle ajax default response
+      _default_response : function( response ){
+        this.$_slider_fields_box.empty().append(response);
+        this.$_slider_fields_box.find('.spinner').hide();
+        this._init_ext_plugins();
+      },
 
-              //reactivate sortable
-              jQuery( '#sortable' ).sortable({
-              placeholder: "ui-state-highlight",
-              update: function(event, ui) {
-                  var newOrder = jQuery(this).sortable( 'toArray' ).toString();
-                  jQuery.post(
-                     ajaxurl,
-                     {
-                        //ADD vars to $_POST
-                        'action':'slider_action' ,
-                        //get the post_id with an hidden input field
-                        'tc_post_id': jQuery( 'input#tc_post_id' ).val(),
-                         // send the nonce along with the request
-                        'SliderCheckNonce' : SliderAjax.SliderCheckNonce,
-                        //position array
-                        'newOrder':newOrder,
-                        //current post slider
-                        'currentpostslider':jQuery( 'select#post_slider_field' ).val()
-                     },
-                     function(response){
-                        //alert( 'The server responded: ' +  response);
-                         slider_update = jQuery( '<div/>' ).addClass( 'updated' )
-                        .css( 'opacity' ,0)
-                        .html( '<div class="message">Slider updated</div>' )
-                        .appendTo( '#update-status' );
-                        slider_update.animate({opacity:0.9}, function(){
-                        slider_update.delay(1200).fadeOut(function()
-                          {
-                            slider_update.remove();
-                          });
-                        });
-                     }
-                  );
-              }
+      //handle reordering slides ajax response
+      _reorder_slides_response : function( response ){
+        var slider_update = $( '<div/>' ).addClass( 'updated' )
+          .css( 'opacity' ,0)
+          .html( '<div class="message">Slider updated</div>' )
+          .appendTo( '#update-status' );
+          slider_update.animate({opacity:0.9}, function(){
+          slider_update.delay(1200).fadeOut(function(){
+              slider_update.remove();
             });
-            jQuery( '#sortable' ).disableSelection();
-            jQuery( '#post_slider_infos .spinner' ).hide();
-          }//end of response
-        );
-      });
-});
+          });
+        this.$_slider_fields_box.find('.spinner').hide();
+        this._init_sortable();
+      },  
+
+      //build the data to pass over $_POST depending on the event
+      _build_data : function( _event ){
+        var _data = {};  
+        
+        switch ( _event ) {
+          case 'new_slider':  
+          case 'select_slider':
+            _data = $.extend( {}, this._data, {
+              'post_slider_name'    : $( 'select#post_slider_field').val(),
+              'new_slider_name'     : $( 'input#slider_field' ).val(),
+            });
+            if ( 'attachment' == this._context )
+              $.extend( _data, this._data, {
+                'slide_title_field'            : $( 'input#slide_title_field' ).val(),
+                'slide_text_field'             : $( 'textarea#slide_text_field' ).val(),
+                'slide_color_field'            : $( 'input#slide_color_field' ).val(),
+                'slide_button_field'           : $( 'input#slide_button_field' ).val(),
+                'slide_link_field'             : $( 'select#slide_link_field' ).val(),
+                'slide_custom_link_field'      : $( 'input#slide_custom_link_field').val(),
+                'slide_link_target_field'      : $( 'input#slide_link_target_field').is(':checked') ? 1 : '',
+                'slide_link_whole_slide_field' : $( 'input#slide_link_whole_slide_field').is(':checked') ? 1 : '',
+             });
+          break;
+          case 'delete_slider':
+            _data = $.extend( {}, this._data, {
+              'delete_slider'       : true,
+              'currentpostslider'   : $( 'select#post_slider_field' ).val(),
+              //reset new_slider_name if needed
+              'new_slider_name'     : null,
+            });
+          break;
+          case 'reorder_slides':
+            _data = $.extend( {}, this._data, {
+              //position array
+              'newOrder'            : this.$_slider_section_box.find('#sortable').sortable( 'toArray' ).toString(),
+              //current post slider
+              'currentpostslider'   : $( 'select#post_slider_field' ).val()
+            });
+          break;
+          default : 
+            _data = this._data;
+
+        }  
+        _data[this._check_field] = this.$_slider_check_field.is(':checked') ? 1 : '';
+        return _data;
+      },
+
+      //init external plugins such as sortable, color pickers, iphone check
+      _init_ext_plugins : function(){
+        this._init_color_picker();
+        this._init_iphone_check();
+        this._init_sortable();
+      },
+
+      //init color picker
+      _init_color_picker : function(){
+        if ( this._color_picker_on ){
+          var $_slide_color_field = $('#slide_color_field');
+          switch ( this._color_picker_func ){
+            case 'farbtastic' :
+              $('#colorfield').farbtastic( $_slide_color_field );    
+              break;
+
+            default:
+              $_slide_color_field.wpColorPicker();
+          }
+        }
+      },
+
+      //init iphonecheck
+      _init_iphone_check : function(){
+        $('.iphonecheck' ).iphoneStyle({ checkedLabel: 'Yes' , uncheckedLabel: 'No' });
+      },
+
+      //init sortable
+      _init_sortable : function(){
+        this.$_slider_section_box.find( '#sortable' ).sortable({
+          placeholder: "ui-state-highlight",
+        }).disableSelection();
+      }
+    });    
+    new CzrSlider();
+  });
+
+})(jQuery);

--- a/inc/assets/js/parts/_main_slider.part.js
+++ b/inc/assets/js/parts/_main_slider.part.js
@@ -9,6 +9,10 @@ var czrapp = czrapp || {};
     //INIT
     init : function() {
       var self = this;
+
+      // cache jQuery el
+      this.$_sliders = $( 'div[id*="customizr-slider"]' );
+
       //@todo EVENT
       //Recenter the slider arrows on resize
       czrapp.$_window.resize( function(){
@@ -28,22 +32,22 @@ var czrapp = czrapp || {};
         return;
 
       if ( 0 !== _delay.length && ! _hover ) {
-        $("#customizr-slider").carousel({
+        this.$_sliders.carousel({
             interval: _delay,
             pause: "false"
         });
       } else if ( 0 !== _delay.length ) {
-        $("#customizr-slider").carousel({
+        this.$_sliders.carousel({
             interval: _delay
         });
       } else {
-        $("#customizr-slider").carousel();
+        this.$_sliders.carousel();
       }
     },
 
     manageHoverClass : function() {
       //add a class to the slider on hover => used to display the navigation arrow
-      $(".carousel").hover( function() {
+      this.$_sliders.hover( function() {
           $(this).addClass('tc-slid-hover');
         },
         function() {
@@ -54,9 +58,9 @@ var czrapp = czrapp || {};
 
     //SLIDER ARROWS
     centerSliderArrows : function() {
-      if ( 0 === $('.carousel').length )
+      if ( 0 === this.$_sliders.length )
           return;
-      $('.carousel').each( function() {
+      this.$_sliders.each( function() {
           var _slider_height = $( '.carousel-inner' , $(this) ).height();
           $('.tc-slider-controls', $(this) ).css("line-height", _slider_height +'px').css("max-height", _slider_height +'px');
       });
@@ -65,16 +69,17 @@ var czrapp = czrapp || {};
 
     //Slider swipe support with hammer.js
     addSwipeSupport : function() {
-      if ( 'function' != typeof($.fn.hammer) )
+      if ( 'function' != typeof($.fn.hammer) || 0 === this.$_sliders.length )
         return;
+      
       //prevent propagation event from sensible children
-      $(".carousel input, .carousel button, .carousel textarea, .carousel select, .carousel a").on("touchstart touchmove", function(ev) {
+      this.$_sliders.on('touchstart touchmove', 'input, button, textarea, select, a:not(".tc-slide-link")', function(ev) {
           ev.stopPropagation();
       });
 
-      var _is_rtl = $('body').hasClass('rtl');
-      $('.carousel' ).each( function() {
-          $(this).hammer().on('swipeleft tap', function() {
+      var _is_rtl = czrapp.$_body.hasClass('rtl');
+      this.$_sliders.each( function() {
+          $(this).hammer().on('swipeleft', function() {
               $(this).carousel( ! _is_rtl ? 'next' : 'prev' );
           });
           $(this).hammer().on('swiperight', function(){
@@ -86,7 +91,7 @@ var czrapp = czrapp || {};
     //Has to be fire on load after all other methods
     //@todo understand why...
     sliderTriggerSimpleLoad : function() {
-      this.triggerSimpleLoad( $( '.carousel .carousel-inner').find('img') );
+      this.triggerSimpleLoad( this.$_sliders.find('.carousel-inner img') );
     }
   };//methods {}
 


### PR DESCRIPTION
  1) Options added:
    - use a custom link
    - link whole slide
    - open link in a _blank target
  2) Further improvements:
    2a) back/admin
      - php
        - unify, where possible/needed, attachment and post metabox
          html structure
        - use minified scripts when WP_DEBUG == true
      - js
        - revamp tc-slider-ajax.js, better structure avoiding code
        duplication
    2b) front
      - php
        - Cache slider's model per slider
        - Store number or rendered sliders and use this value as part of
          the slider id
      - js
        - Cache sliders elements
        - Allow multiple sliders in the same page
        - Handle whole slide linking in mobiles ( suppress slide next on
          tap event )