### PR TITLE
Fix: slider-controls color when clicked

### DIFF
--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -1124,7 +1124,7 @@ footer#footer .colophon .social-block a {
   font-size: 120px;
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.4);
   z-index: 10;
-  color: #999;
+  color: inherit;
   line-height: 16px;
   vertical-align: middle;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -1137,6 +1137,9 @@ footer#footer .colophon .social-block a {
   filter: alpha(opacity=90);
   outline : none;
 }
+.tc-carousel-control:focus {
+  color: inherit;
+}
 .tc-slider-controls {
   position: absolute;
   bottom: 0;
@@ -1144,6 +1147,7 @@ footer#footer .colophon .social-block a {
   line-height: 500px;/* OVERRIDEN BY DYNAMIC!!!! PHP + JS */
   width: 10%;
   opacity: 0;
+  color: #999;
 }
 .tc-slid-hover .tc-slider-controls {
   opacity: 1;

--- a/inc/assets/less/tc_skin_rules.less
+++ b/inc/assets/less/tc_skin_rules.less
@@ -349,7 +349,7 @@ td {
 }
 
 /* SLIDER CONTROLS */
-.tc-carousel-control:focus, .tc-carousel-control:hover {
+.tc-carousel-control:hover {
   color: @lnkCol;
 }
 


### PR DESCRIPTION
Should fix the floowing issue:

When you click on an arrow, it keeps the hover color
even when the mouse is out.

p.s.
tested in chrome and ff
I think it's fine.