### PR TITLE
Fix: video post format, show full content in alternate layout

### DIFF
--- a/inc/parts/class-content-post_list.php
+++ b/inc/parts/class-content-post_list.php
@@ -234,7 +234,7 @@ class TC_post_list {
       $_sub_class = 'entry-content';
       $_content   = '<p class="format-icon"></p>';
     }
-    elseif ( in_array( get_post_format(), array( 'quote', 'status', 'link', 'aside' ) ) )
+    elseif ( in_array( get_post_format(), array( 'quote', 'status', 'link', 'aside', 'video' ) ) )
     {
       $_sub_class = sprintf( 'entry-content %s' , $_icon_class );
       $_content   = sprintf( '%1$s%2$s',


### PR DESCRIPTION
https://wordpress.org/support/topic/videos-are-not-available-on-the-main-for-video-type-posts-any-more?replies=1
Mmm, why was that removed?

p.s.
I'll be away in 5minutes or so, for the rest of the day (pretty much)