### PR TITLE
Fix: display slider-loading-gif only if js enabled

### DIFF
--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -333,11 +333,16 @@ class TC_slider {
     if ( 'demo' != $slider_name_id && ( 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_display_slide_loader') ) || ! apply_filters( 'tc_display_slider_loader' , true ) ) )
       return;
     ?>
-      <div class="tc-slider-loader-wrapper">
+      <div id="tc-slider-loader-wrapper" class="tc-slider-loader-wrapper" style="display:none;">
         <div class="tc-img-gif-loader">
           <img data-no-retina alt="loading" src="<?php echo apply_filters('tc_slider_loader_src' , sprintf( '%1$s/%2$s' , TC_BASE_URL , 'inc/assets/img/slider-loader.gif') ) ?>">
         </div>
       </div>
+      <script type="text/javascript">
+      <!--
+        document.getElementById("tc-slider-loader-wrapper").style.display="block";
+      -->
+      </script>
     <?php
   }
 

--- a/inc/parts/class-content-slider.php
+++ b/inc/parts/class-content-slider.php
@@ -333,14 +333,14 @@ class TC_slider {
     if ( 'demo' != $slider_name_id && ( 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_display_slide_loader') ) || ! apply_filters( 'tc_display_slider_loader' , true ) ) )
       return;
     ?>
-      <div id="tc-slider-loader-wrapper" class="tc-slider-loader-wrapper" style="display:none;">
+      <div id="tc-slider-loader-wrapper-<?php echo self::$rendered_slides ?>" class="tc-slider-loader-wrapper" style="display:none;">
         <div class="tc-img-gif-loader">
           <img data-no-retina alt="loading" src="<?php echo apply_filters('tc_slider_loader_src' , sprintf( '%1$s/%2$s' , TC_BASE_URL , 'inc/assets/img/slider-loader.gif') ) ?>">
         </div>
       </div>
       <script type="text/javascript">
       <!--
-        document.getElementById("tc-slider-loader-wrapper").style.display="block";
+        document.getElementById("tc-slider-loader-wrapper-<?php echo self::$rendered_slides ?>").style.display="block";
       -->
       </script>
     <?php


### PR DESCRIPTION
Following to this ->
https://wordpress.org/support/topic/replace-slider-loadergif?replies=4#post-7128317

What do you think about the pure javascript solution in this PR?