### PR TITLE
New menu fixes

### DIFF
--- a/inc/admin/js/parts/_control.js
+++ b/inc/admin/js/parts/_control.js
@@ -286,14 +286,24 @@
       }
     },
     'tc_menu_style' : {
-      controls: [
-        'tc_menu_type',
-        'tc_menu_submenu_fade_effect',
-        'tc_menu_submenu_item_move_effect',
-        'tc_menu_resp_dropdown_limit_to_viewport'
-      ],
-      callback: function (to) {
-        return 'aside' != to;
+      show : {
+        controls: [
+          'tc_menu_type',
+          'tc_menu_submenu_fade_effect',
+          'tc_menu_submenu_item_move_effect',
+          'tc_menu_resp_dropdown_limit_to_viewport'
+        ],
+        callback: function (to) {
+          return 'aside' != to;
+        }
+      },
+      hide : {
+        controls: [
+          'tc_display_menu_label'
+        ],
+        callback: function (to) {
+          return 'aside' != to;
+        }
       }
     }
   };
@@ -380,6 +390,7 @@
         controls  : _get_dependants(setId),
       };
 
+
       _.map( _params.controls , function( depSetId ) {
         _set_single_dependant_control_visibility( depSetId , _params);
       } );
@@ -399,8 +410,8 @@
 
         if ( 'show' == _action && _callback(to) )
           _bool = true;
-        if ( 'hide' == _action && _callback(to) )
-          _bool = false;
+        if ( 'hide' == _action && ! _callback(to) )
+          _bool = true;
         if ( 'both' == _action )
           _bool = _callback(to);
 
@@ -448,10 +459,10 @@
       api.control('tc_theme_options[tc_menu_position]').container.find('select').selecter('destroy').selecter({});
     } );
 
-    var _header_layout = api('tc_theme_options[tc_header_layout]').get();
     //when user changes the menu syle (side or regular), refresh the menu position according to the header layout
     api('tc_theme_options[tc_menu_style]').callbacks.add( function(to) {
-      api('tc_theme_options[tc_menu_position]').set( 'right' == _header_layout ? 'pull-menu-right' : 'pull-menu-left' );
+      var _header_layout = api('tc_theme_options[tc_header_layout]').get();
+      api('tc_theme_options[tc_menu_position]').set( 'left' == _header_layout ? 'pull-menu-right' : 'pull-menu-left' );
       //refresh the selecter
       api.control('tc_theme_options[tc_menu_position]').container.find('select').selecter('destroy').selecter({});
     } );

--- a/inc/admin/js/theme-customizer-control.js
+++ b/inc/admin/js/theme-customizer-control.js
@@ -474,14 +474,24 @@ if(this.context=f.context===b?null:f.context,this.opts.createSearchChoice&&""!==
       }
     },
     'tc_menu_style' : {
-      controls: [
-        'tc_menu_type',
-        'tc_menu_submenu_fade_effect',
-        'tc_menu_submenu_item_move_effect',
-        'tc_menu_resp_dropdown_limit_to_viewport'
-      ],
-      callback: function (to) {
-        return 'aside' != to;
+      show : {
+        controls: [
+          'tc_menu_type',
+          'tc_menu_submenu_fade_effect',
+          'tc_menu_submenu_item_move_effect',
+          'tc_menu_resp_dropdown_limit_to_viewport'
+        ],
+        callback: function (to) {
+          return 'aside' != to;
+        }
+      },
+      hide : {
+        controls: [
+          'tc_display_menu_label'
+        ],
+        callback: function (to) {
+          return 'aside' != to;
+        }
       }
     }
   };
@@ -568,6 +578,7 @@ if(this.context=f.context===b?null:f.context,this.opts.createSearchChoice&&""!==
         controls  : _get_dependants(setId),
       };
 
+
       _.map( _params.controls , function( depSetId ) {
         _set_single_dependant_control_visibility( depSetId , _params);
       } );
@@ -587,8 +598,8 @@ if(this.context=f.context===b?null:f.context,this.opts.createSearchChoice&&""!==
 
         if ( 'show' == _action && _callback(to) )
           _bool = true;
-        if ( 'hide' == _action && _callback(to) )
-          _bool = false;
+        if ( 'hide' == _action && ! _callback(to) )
+          _bool = true;
         if ( 'both' == _action )
           _bool = _callback(to);
 
@@ -636,10 +647,10 @@ if(this.context=f.context===b?null:f.context,this.opts.createSearchChoice&&""!==
       api.control('tc_theme_options[tc_menu_position]').container.find('select').selecter('destroy').selecter({});
     } );
 
-    var _header_layout = api('tc_theme_options[tc_header_layout]').get();
     //when user changes the menu syle (side or regular), refresh the menu position according to the header layout
     api('tc_theme_options[tc_menu_style]').callbacks.add( function(to) {
-      api('tc_theme_options[tc_menu_position]').set( 'right' == _header_layout ? 'pull-menu-right' : 'pull-menu-left' );
+      var _header_layout = api('tc_theme_options[tc_header_layout]').get();
+      api('tc_theme_options[tc_menu_position]').set( 'left' == _header_layout ? 'pull-menu-right' : 'pull-menu-left' );
       //refresh the selecter
       api.control('tc_theme_options[tc_menu_position]').container.find('select').selecter('destroy').selecter({});
     } );

--- a/inc/assets/js/parts/_main_side_nav.part.js
+++ b/inc/assets/js/parts/_main_side_nav.part.js
@@ -111,8 +111,7 @@ var czrapp = czrapp || {};
       //handles the page wrapper button fade in / out on click
       var _event = evt || event,
           $_clicked_btn = $( _event.target ),
-          _is_opening   = $('#tc-page-wrap').has( $_clicked_btn).length > 0,
-          that = this;
+          _is_opening   = $('#tc-page-wrap').has( $_clicked_btn).length > 0;
 
       this.$_page_wrapper_btn.each( function(){
         $(this).fadeTo( 500 , _is_opening ? 0 : 1 , function() {
@@ -123,8 +122,6 @@ var czrapp = czrapp || {};
    },
 
    _transition_end_callback : function (){
-     var self = this;
-
      czrapp.$_body.removeClass( 'animating ' +  this._anim_type)
                   .toggleClass( 'tc-sn-visible' )
                   .trigger( this._anim_type + '_end' );

--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -1068,12 +1068,12 @@ style when side nav visible is actually rendered inline TC_menu.tc_set_sidenav_s
 /* END FIXED HEADER ISSUE */
 
 /* SIDE MENU START */
-/*.btn-toggle-nav .menu-btn,
+/*.btn-toggle-nav .menu-btn,*/
 #tc-sn .nav-collapse {
   background: #fff;
   background: rgba(255,255,255,.9);
   filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#CCFFFFFF, endColorstr=#CCFFFFFF)";
-}*/
+}
 .btn-toggle-nav .menu-btn:focus, .btn-toggle-nav .menu-btn:hover {
   outline: none;
   outline-offset: inherit;
@@ -1242,11 +1242,11 @@ style when side nav visible is actually rendered inline TC_menu.tc_set_sidenav_s
 
 .nav-collapse.in + .btn-toggle-nav .icon-bar:nth-child(3),
 .tc-sn-visible .btn-toggle-nav .icon-bar:nth-child(3){
-  -webkit-transform: translate(0px, -4px) rotate(45deg) scalex(1.3);
-     -moz-transform: translate(0px, -4px) rotate(45deg) scalex(1.3);
-      -ms-transform: translate(0px, -4px) rotate(45deg) scalex(1.3);
-       -o-transform: translate(0px, -4px) rotate(45deg) scalex(1.3);
-          transform: translate(0px, -4px) rotate(45deg) scalex(1.3);
+  -webkit-transform: translate(0px, -3px) rotate(45deg) scalex(1.3);
+     -moz-transform: translate(0px, -3px) rotate(45deg) scalex(1.3);
+      -ms-transform: translate(0px, -3px) rotate(45deg) scalex(1.3);
+       -o-transform: translate(0px, -3px) rotate(45deg) scalex(1.3);
+          transform: translate(0px, -3px) rotate(45deg) scalex(1.3);
 }
 
 .csstransforms .nav-collapse.in + .btn-toggle-nav .icon-bar,

--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -922,17 +922,17 @@ li.dropdown.active>.dropdown-toggle, .navbar .nav li.dropdown.open.active>.dropd
   }
 }
 /* ADJUST LEFT AND RIGHT MENU POSITIONS => align with socials (left) and tagline (right) */
-.logo-left .navbar div>ul.nav>.menu-item:last-child>a {
-  padding-right: 0;
-}
 .navbar .nav {
   margin-right: 0px;
 }
-
-.logo-right .navbar div>ul.nav>.menu-item:first-child>a {
+.tc-header .btn-toggle-nav.pull-left,
+.pull-menu-left .navbar div>ul.nav>.menu-item:first-child>a {
   padding-left: 5px;
 }
-
+.tc-header .btn-toggle-nav.pull-right,
+.pull-menu-right .navbar div>ul.nav>.menu-item:last-child>a {
+  padding-right: 0px;
+}
 .pull-menu-left .nav-collapse{
   float: left
 }
@@ -1079,8 +1079,9 @@ style when side nav visible is actually rendered inline TC_menu.tc_set_sidenav_s
   outline-offset: inherit;
   background: none;
 }
-#tc-sn .tc-sn-inner.nav-collapse .nav{
+#tc-sn .tc-sn-inner.nav-collapse .nav {
   display: block;
+  margin-top: 10px;
 }
 
 .sn-nav-wrapper {
@@ -1115,7 +1116,7 @@ style when side nav visible is actually rendered inline TC_menu.tc_set_sidenav_s
 .nav .dropdown-menu a {
   color: #777;
 }
-.navbar div > ul.nav > .menu-item:first-child > a {
+.navbar div > ul.sn-nav > .menu-item:first-child > a {
   padding-left: 20px;
 }
 


### PR DESCRIPTION
Following small fixes.
In each commit a summary of the changes.

We still have to decide the behavior of the header menu button-div in some circumstances:
1) sticky-enabled with no tagline (clear: both?)
2) no tagline (clear:both, and some margin?)
3) tagline but no socials (and logo on the left -> menu button on the right)
the third is pretty tricky, cause clear:both will place the menu-button below the tagline leaving a lot of useless space on the left

I don't know whether or not you want to merge this, but please take a look at the small fixes asap, otherwise I have to make another PR :D