### PR TITLE
Fix: front-js, dropdown-to-viewport fix

### DIFF
--- a/inc/assets/js/parts/bootstrap.js
+++ b/inc/assets/js/parts/bootstrap.js
@@ -1656,8 +1656,7 @@ var TCParams = TCParams || {};
 
       if ( TCParams && 1 == TCParams.dropdowntoViewport )
       {
-        var tcVisible = $('body').hasClass('sticky-enabled') ? $(window).height() : ($(window).height() - $('.navbar-wrapper').offset().top);
-        tcVisible = ( tcVisible - 90 ) > 80 ? tcVisible - 90 : 300;
+        var tcVisible = czrapp.$_window.height() - this.$element.offset().top + czrapp.$_window.scrollTop();
         this.$element.css('max-height' , tcVisible + 'px');
       }
       else if ( TCParams && 1 != TCParams.dropdowntoViewport && 1 == TCParams.stickyHeader )
@@ -1667,7 +1666,7 @@ var TCParams = TCParams || {};
           $('.back-to-top').trigger('click');
         }
         else {
-          ('html, body').animate({
+          $('html, body').animate({
                   scrollTop: 0
               }, 700);
         }


### PR DESCRIPTION
The new algorithm is based on the effective position of the expanding
element in the viewport, which is computed as the top offset of the
element minus the window scroll top.

Tested with my smartphone both when sticky-header on (scrolling or not)
and sticky-header off (scrolling or not)

p.s.
additionally a small typo fix, missing jquery alias ($) when trying
to animate html,body if stiky-header and no TCParams.dropdowntoViewport