### PR TITLE
Fix: set the second-menu .nav-collapse background to inherit for

### DIFF
--- a/inc/parts/class-header-menu.php
+++ b/inc/parts/class-header-menu.php
@@ -452,6 +452,7 @@ if ( ! class_exists( 'TC_menu' ) ) :
             -webkit-box-shadow: none;
             -moz-box-shadow: none;
             box-shadow: none;
+            background: inherit;
           }
           .tc-sticky-header.sticky-enabled #tc-page-wrap .nav-collapse, #tc-page-wrap .tc-second-menu-hide-when-mobile .nav-collapse.collapse .nav {
             display:none;


### PR DESCRIPTION
mq<=979px, otherwise it will be ruled by the follwingt rule for
the mobile menu:
@media (max-width: 979px)
.no-navbar .nav-collapse, .nav-collapse.collapse {
  background: #ffffff transparent;
  background: rgba(255, 255, 255, 0.9);
  filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#CCFFFFFF, endColorstr=#CCFFFFFF)";
  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#CCFFFFFF, endColorstr=#CCFFFFFF)";
}