### PR TITLE
Fix: issue when ww< 400px and side menu on the left

### DIFF
--- a/inc/assets/less/tc_custom_responsive.less
+++ b/inc/assets/less/tc_custom_responsive.less
@@ -708,6 +708,7 @@
   /* Hack*/
   /* prevent pan in mobiles max-width: 400px: should we apply this for all tc-is-mobile losing the page scroll down ?? */
   .tc-sn-visible #tc-page-wrap { position: absolute; width: 100%;}
+  .tc-sn-visible:not(.sn-close) #tc-page-wrap { left: initial !important;}
   /*end prevent overflows in mobiles */
 }
 @media (max-width: 320px) {


### PR DESCRIPTION
When window's width <=400px side menu on the left and open, in mobile
devs happened that the absolute position of the page-wrap + its left
offset made the body's width overflow the window so the side-nav
(width:100%) overflowed the visible viewport too. This isn't
reproducible just shrinking the window in desktop's browsers.
(I think it has to do with the pan)
The small proposed CSS should (tested on my smartphone) solve the issue.

p.s.
The reason why we use the absolute position for the page-wrap, in place
of the fixed (former) one, is that it caused the page scroll up when
sticky header and scrolling.