### PR TITLE
Fix: jquery menu separator creation in compatible way with old browsers

### DIFF
--- a/inc/assets/js/parts/_main_userxp.part.js
+++ b/inc/assets/js/parts/_main_userxp.part.js
@@ -307,10 +307,7 @@ var czrapp = czrapp || {};
       if ( 'navbar' == _to )
         $( '.secondary-menu-separator', that.$_sn_wrap).remove();
       else {
-        $_sep = $( '<li/>', {
-          class : 'menu-item secondary-menu-separator',
-          html : '<hr class="featurette-divider">'
-        } );
+        $_sep = $( '<li class="menu-item secondary-menu-separator"><hr class="featurette-divider"></hr></li>' );
 
         switch(userOption) {
           case 'in-sn-before' :


### PR DESCRIPTION
Sorry but we cannot use class for example with ie8, it's a reserved word