### PR TITLE
Fix: do not update the tb post meta as soon as you enter tha add post

### DIFF
--- a/inc/admin/class-fire-admin_init.php
+++ b/inc/admin/class-fire-admin_init.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'TC_admin_init' ) ) :
     */
     function tc_refresh_thumbnail( $post_id ) {
       // If this is just a revision, don't send the email.
-      if ( wp_is_post_revision( $post_id ) )
+      if ( empty( $_POST ) || wp_is_post_revision( $post_id ) )
         return;
 
       if ( ! class_exists( 'TC_post_thumbnails' ) )


### PR DESCRIPTION
page


p.s.
This is more a reminder.
Fixes the issue reported here: http://presscustomizr.com/support-forums/topic/conflict-with-press-permit-core/
Basically `save_post` is fired also when you enter the add new post page.
This is mainly a plugin issue which we facilitated.
Anyway there's no reason, imho, to add an empty post meta in that case.

The same thing should be done in fpu too (let me know if you want I make a PR also there or you'll do it manually :page_facing_up: )