### PR TITLE
Fix: compatibility fixes with old wp version

### DIFF
--- a/inc/admin/js/parts/_control.js
+++ b/inc/admin/js/parts/_control.js
@@ -4,7 +4,8 @@
  * @since Customizr 1.0
  */
 (function (wp, $, _) {
-  var api = wp.customize;
+  var api = wp.customize,
+      $_nav_section_container;
 
   /**
    * @constructor
@@ -531,7 +532,7 @@
   //change the 'nav' section controls opacity based on the booleand value of a setting (tc_theme_options[tc_hide_all_menus])
   var _hideAllmenusActions = function(to, from, setId) {
     setId = setId ||'tc_theme_options[tc_hide_all_menus]';
-    var $_controls = api.section('nav').container.find('li.customize-control').not( api.control(setId).container );
+    var $_controls = $_nav_section_container.find('li.customize-control').not( api.control(setId).container );
     $_controls.each( function() {
       if ( $(this).is(':visible') )
         $(this).fadeTo( 500 , true === to ? 0.5 : 1); //.fadeTo() duration, opacity, callback
@@ -548,9 +549,11 @@
     //additional dependencies
     _handle_grid_dependencies();
     _header_layout_dependency();
+ 
+    $_nav_section_container = 'function' != typeof api.section ? $('li#accordion-section-nav') : api.section('nav').container;
 
     //on nav section open
-    api.section('nav').container.on( 'click keydown', '.accordion-section-title', function(e) {
+    $_nav_section_container.on( 'click keydown', '.accordion-section-title', function(e) {
       //special treatment for click events
       if ( api.utils.isKeydownButNotEnterEvent( event ) ) {
         return;

--- a/inc/assets/js/parts/_main_base.part.js
+++ b/inc/assets/js/parts/_main_base.part.js
@@ -214,7 +214,8 @@ var czrapp = czrapp || {};
       var self = this;
       _.map( cbs, function(cb) {
         if ( 'function' == typeof(self[cb]) ) {
-          self[cb].apply(self, 'undefined' == typeof( args ) ? Array() : args );
+          args = 'undefined' == typeof( args ) ? Array() : args ;  
+          self[cb].apply(self, args );
           czrapp.trigger( cb, _.object( _.keys(args), args ) );
         }
       });//_.map

--- a/inc/class-fire-utils_settings_map.php
+++ b/inc/class-fire-utils_settings_map.php
@@ -2085,7 +2085,7 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
       //adapt the nav section description for v4.3 (menu in the customizer from now on)
       if ( version_compare( $wp_version, '4.3', '<' ) ) {
         $nav_section_desc .= "<br/>" . sprintf( __("You can create new menu and edit your menu's content %s." , "customizr"),
-          sprintf( '<strong><a href="%1$s" target="_blank" title="%3$s">%2$s &raquo;</a><strong>',
+          sprintf( '<strong><a href="%1$s" target="_blank" title="%3$s">%2$s &raquo;</a></strong>',
             admin_url('nav-menus.php'),
             __("on the Menus screen in the Appearance section" , "customizr"),
             __("create/edit menus", "customizr")

--- a/inc/parts/class-header-nav_walker.php
+++ b/inc/parts/class-header-nav_walker.php
@@ -16,14 +16,14 @@ if ( ! class_exists( 'TC_nav_walker' ) ) :
     function __construct($_location) {
       self::$instance =& $this;
       $this -> tc_location = $_location;
-      add_filter( 'nav_menu_css_class' , array($this, 'tc_add_bootstrap_classes'), 10, 4 );
+      add_filter( 'tc_nav_menu_css_class' , array($this, 'tc_add_bootstrap_classes'), 10, 4 );
     }
 
 
     /**
     * hook : nav_menu_css_class
     */
-    function tc_add_bootstrap_classes($classes, $item, $args, $depth ) {
+    function tc_add_bootstrap_classes($classes, $item, $args, $depth ) { 
       //check if $item is a dropdown ( a parent )
       //this is_dropdown property has been added in the the display_element() override method
       if ( $item -> is_dropdown ) {
@@ -75,6 +75,8 @@ if ( ! class_exists( 'TC_nav_walker' ) ) :
       //we add a property here
       //will be used in override start_el() and class filter
       $element->is_dropdown = ! empty( $children_elements[$element->ID]);
+
+      $element->classes = apply_filters( 'tc_nav_menu_css_class', $element->classes, $element, $args, $depth );
 
       //let the parent do the rest of the job !
       parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output);


### PR DESCRIPTION
1) customize: _control.js
old wp versions don't have wp.customize.section (see gc pull #4)
same method

2) customize-preview: _main_base.part.js
when in customize and preview loaded I got this error:
Uncaught TypeError: Cannot convert undefined or null to object
on line:
https://github.com/Nikeo/customizr/blob/master/inc/assets/js/parts/_main_base.part.js#L218

and most of the preview js break

the simple change in this pr will fix it

3) customize: class-fire-utils_settings_map.php
Simple wrong strong tag closing. This made the the preview iframe
overlay the customize settings (all the preview in the left content), due to html breakage

4) class-header-nav_walker.php
Avoid using wp filter nav_menu_css_class which could cause api breakage
with old wp versions, and most likely, some plugin.
Replace it with a custom filter hook tc_nav_menu_css_class we fire over
the element's classes in our nav_walker display_element override.

To me these simple changes sound good and should not cause any issue,
but just take a second look on them ;)