### PR TITLE
Fix: properly remove box around navbar when no menu is set

### DIFF
--- a/inc/parts/class-header-header_main.php
+++ b/inc/parts/class-header-header_main.php
@@ -592,6 +592,10 @@ if ( ! class_exists( 'TC_header_main' ) ) :
      		$_classes = array_merge( $_classes, array('tc-no-sticky-header') );
      	}
 
+        //No navbar box
+        if ( 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_display_boxed_navbar') ) )
+            $_classes = array_merge( $_classes , array('no-navbar' ) );
+
       //SKIN CLASS
       $_skin = sprintf( 'skin-%s' , basename( TC_init::$instance -> tc_get_style_src() ) );
       array_push( $_classes, substr( $_skin , 0 , strpos($_skin, '.') ) );

--- a/inc/parts/class-header-menu.php
+++ b/inc/parts/class-header-menu.php
@@ -437,9 +437,6 @@ if ( ! class_exists( 'TC_menu' ) ) :
     * @since Customizr 3.2.0
     */
     function tc_add_body_classes($_classes) {
-      if ( 1 != esc_attr( TC_utils::$inst->tc_opt( 'tc_display_boxed_navbar') ) )
-        array_push( $_classes , 'no-navbar' );
-
       //menu type class
       $_menu_type = $this -> tc_is_sidenav_enabled() ? 'tc-side-menu' : 'tc-regular-menu';
       array_push( $_classes, $_menu_type );


### PR DESCRIPTION
Bug reported here:
https://wordpress.org/support/topic/dispay-menu-in-a-box?replies=6

Basically when no menu is set body class to not display the box is not
added because the filter callback is set just when menu are shown in the
class-header-menu.php

Moving the class adding to class-header-menu.php, which I think is a
more proper place for it 'cause it regards the whole navbar-wrapper more
than menus, solves the issue.