### PR TITLE
Fix: hide menu controls on nav section expanded only for newer wp

### DIFF
--- a/inc/admin/js/parts/_control.js
+++ b/inc/admin/js/parts/_control.js
@@ -114,13 +114,15 @@
     //favicon note on load and on change(since wp 4.3)
     _handleFaviconNote();
 
-    $_nav_section_container = 'function' != typeof api.section ? $('li#accordion-section-nav') : api.section('nav').container;
+    if ( 'function' == typeof api.section ) {
+      $_nav_section_container = api.section('nav').container;
 
-    //on nav section open
-    api.section('nav').expanded.callbacks.add( function() {
-      _hideAllmenusActions( api('tc_theme_options[tc_hide_all_menus]').get() );
-    });//add()
-
+      //on nav section open
+      api.section('nav').expanded.callbacks.add( function() {
+        _hideAllmenusActions( api('tc_theme_options[tc_hide_all_menus]').get() );
+      });//add()
+    } else
+      $_nav_section_container = $('li#accordion-section-nav');    
     //specific callback when for the tc_hide_all_menus setting
     api('tc_theme_options[tc_hide_all_menus]').callbacks.add( _hideAllmenusActions );
   };


### PR DESCRIPTION
versions avoiding conflicts with old wp versions

Basically we hide them just when api.section is a function, 'cause we don't need that for old wp versions which also don't have that function.
Just a question, did you test the new code with 4.1<=wp<4.3 ?