### PR TITLE
Fix: Allow the expanded grid title to be translated with qtranslate

### DIFF
--- a/inc/class-fire-plugins_compat.php
+++ b/inc/class-fire-plugins_compat.php
@@ -186,6 +186,9 @@ if ( ! class_exists( 'TC_plugins_compat' ) ) :
       function tc_change_transport( $value , $set ) {
         return ('transport' == $set) ? 'refresh' : $value;
       }
+      //outputs the qtranslate translation for the grid sticky title
+      add_filter( 'tc_grid_expanded_title', 'tc_apply_qtranslate');
+
       //outputs correct urls for current language : in logo, slider
       add_filter( 'tc_slide_link_url' , 'tc_url_lang' );
       add_filter( 'tc_logo_link_url' , 'tc_url_lang');

--- a/inc/parts/class-content-post_list_grid.php
+++ b/inc/parts/class-content-post_list_grid.php
@@ -476,11 +476,12 @@ if ( ! class_exists( 'TC_post_list_grid' ) ) :
           if ( ! $this -> tc_force_current_post_expansion() )
               return $_html;
           global $post;
-          $_html = sprintf('%1$s<h2 class="entry-title">%2$s</h2>',
-              $_html,
-              apply_filters( 'tc_the_title', $post->post_title )
-          );
-          return apply_filters( 'tc_grid_expanded_title', $_html );
+          $_title = apply_filters( 'tc_grid_expanded_title' , $post->post_title );
+          $_title = apply_filters( 'tc_the_title'           , $_title );
+          $_title = apply_filters( 'tc_grid_expanded_title_html', sprintf('<h2 class="entry-title">%1$s</h2>',
+              $_title
+          ) );
+          return $_html . $_title;
         }
 
 


### PR DESCRIPTION
1) tc_grid_expanded_title filter now filters just the post title, while
before, because of a typo I think, it filtered both the title html and
the excerpt
2) apply qtranslate to tc_grid_expanded_title filter hook

against 149e927763
fixes #287