### PR TITLE
Fix: Woccomerce's product tabs not showing if Smooth scroll on click …

### DIFF
--- a/inc/assets/js/parts/_main_base.part.js
+++ b/inc/assets/js/parts/_main_base.part.js
@@ -135,6 +135,31 @@ var czrapp = czrapp || {};
     },
 
 
+    //@return bool
+    isSelectorAllowed : function( $_el, skip_selectors, requested_sel_type ) {
+      var sel_type = 'ids' == requested_sel_type ? 'id' : 'class',
+      _selsToSkip   = skip_selectors[requested_sel_type];
+
+      //check if option is well formed
+      if ( 'object' != typeof(skip_selectors) || ! skip_selectors[requested_sel_type] || ! $.isArray( skip_selectors[requested_sel_type] ) || 0 === skip_selectors[requested_sel_type].length )
+        return true;
+
+      //has a forbidden parent?
+      if ( $_el.parents( _selsToSkip.map( function( _sel ){ return 'id' == sel_type ? '#' + _sel : '.' + _sel; } ).join(',') ).length > 0 )
+        return false;
+
+      //has requested sel ?
+      if ( ! $_el.attr( sel_type ) )
+        return true;
+
+      var _elSels       = $_el.attr( sel_type ).split(' '),
+          _filtered     = _elSels.filter( function(classe) { return -1 != $.inArray( classe , _selsToSkip ) ;});
+
+      //check if the filtered selectors array with the non authorized selectors is empty or not
+      //if empty => all selectors are allowed
+      //if not, at least one is not allowed
+      return 0 === _filtered.length;
+    },
 
     /***************************************************************************
     * Event methods, offering the ability to bind to and trigger events.
@@ -246,6 +271,9 @@ var czrapp = czrapp || {};
     },
     isReponsive : function() {
       return czrapp.isReponsive();
+    },
+    isSelectorAllowed: function( $_el, skip_selectors, requested_sel_type ) {
+      return czrapp.isSelectorAllowed( $_el, skip_selectors, requested_sel_type );    
     }
 
   };//_methods{}

--- a/inc/assets/js/parts/_main_userxp.part.js
+++ b/inc/assets/js/parts/_main_userxp.part.js
@@ -61,8 +61,23 @@ var czrapp = czrapp || {};
       if ( ! TCParams.anchorSmoothScroll || 'easeOutExpo' != TCParams.anchorSmoothScroll )
             return;
 
-      var _excl_sels = ( TCParams.anchorSmoothScrollExclude && _.isArray( TCParams.anchorSmoothScrollExclude ) ) ? TCParams.anchorSmoothScrollExclude.join(',') : '';
-      $('a[href^="#"]', '#content').not( _excl_sels ).click(function () {
+      var _excl_sels = ( TCParams.anchorSmoothScrollExclude && _.isArray( TCParams.anchorSmoothScrollExclude.simple ) ) ? TCParams.anchorSmoothScrollExclude.simple.join(',') : '',
+          self = this,
+          $_links = $('a[href^="#"]', '#content').not(_excl_sels);
+
+      //Deep exclusion
+      //are ids and classes selectors allowed ?
+      //all type of selectors (in the array) must pass the filter test
+      _deep_excl = _.isObject( TCParams.anchorSmoothScrollExclude.deep ) ? TCParams.anchorSmoothScrollExclude.deep : null ;
+      if ( _deep_excl )
+        _links = _.toArray($_links).filter( function ( _el ) {
+          return ( 2 == ( ['ids', 'classes'].filter( 
+                        function( sel_type) { 
+                            return self.isSelectorAllowed( $(_el), _deep_excl, sel_type); 
+                        } ) ).length 
+                );
+        });
+      $(_links).click( function () {
         var anchor_id = $(this).attr("href");
 
         //anchor el exists ?

--- a/inc/assets/js/parts/jqueryextLinks.js
+++ b/inc/assets/js/parts/jqueryextLinks.js
@@ -71,6 +71,9 @@
     * @return boolean
     */
     Plugin.prototype._is_selector_allowed = function( requested_sel_type ) {
+      if ( czrapp )
+        return czrapp.isSelectorAllowed( this.$_el, this.options.skipSelectors, requested_sel_type);
+
       var sel_type = 'ids' == requested_sel_type ? 'id' : 'class',
           _selsToSkip   = this.options.skipSelectors[requested_sel_type];
 

--- a/inc/assets/js/parts/tc-js-params.js
+++ b/inc/assets/js/parts/tc-js-params.js
@@ -16,7 +16,10 @@ var TCParams = TCParams || {
   centerSliderImg : 1,
 	SmoothScroll: { Enabled : 1 , Options : {} },
 	anchorSmoothScroll: "linear",
-  anchorSmoothScrollExclude : ['[class*=edd]', '.tc-carousel-control', '.carousel-control', '[data-toggle="modal"]', '[data-toggle="dropdown"]', '[data-toggle="tooltip"]', '[data-toggle="popover"]', '[data-toggle="collapse"]', '[data-toggle="tab"]', '[class*=upme]', '[class*=um-]'],
+  anchorSmoothScrollExclude : {
+      simple : ['[class*=edd]', '.tc-carousel-control', '.carousel-control', '[data-toggle="modal"]', '[data-toggle="dropdown"]', '[data-toggle="tooltip"]', '[data-toggle="popover"]', '[data-toggle="collapse"]', '[data-toggle="tab"]', '[class*=upme]', '[class*=um-]'],
+      deep : { classes : ['wc-tabs'], ids : [] }
+    },
 	stickyCustomOffset: { _initial : 0, _scrolling : 0, options : { _static : true, _element : "" } },
 	stickyHeader: 1,
 	dropdowntoViewport: 1,

--- a/inc/class-fire-resources.php
+++ b/inc/class-fire-resources.php
@@ -199,9 +199,16 @@ if ( ! class_exists( 'TC_resources' ) ) :
 			$has_post_comments 	= ( 0 != $wp_query -> post_count && comments_open() && get_comments_number() != 0 ) ? true : false;
 
 			//adds the jquery effect library if smooth scroll is enabled => easeOutExpo effect
-			$anchor_smooth_scroll 		= ( false != esc_attr( TC_utils::$inst->tc_opt( 'tc_link_scroll') ) ) ? 'easeOutExpo' : 'linear';
+			$anchor_smooth_scroll 		  = ( false != esc_attr( TC_utils::$inst->tc_opt( 'tc_link_scroll') ) ) ? 'easeOutExpo' : 'linear';
 			if ( false != esc_attr( TC_utils::$inst->tc_opt( 'tc_link_scroll') ) )
 				wp_enqueue_script('jquery-effects-core');
+            $anchor_smooth_scroll_exclude =  apply_filters( 'tc_anchor_smoothscroll_excl' , array(
+                'simple' => array( '[class*=edd]' , '.tc-carousel-control', '.carousel-control', '[data-toggle="modal"]', '[data-toggle="dropdown"]', '[data-toggle="tooltip"]', '[data-toggle="popover"]', '[data-toggle="collapse"]', '[data-toggle="tab"]', '[class*=upme]', '[class*=um-]' ),
+                'deep'   => array(
+                  'classes' => array('wc-tabs'),
+                  'ids'     => array()
+                ) 
+            ));
 
       $smooth_scroll_enabled = apply_filters('tc_enable_smoothscroll', ! wp_is_mobile() && 1 == esc_attr( TC_utils::$inst->tc_opt( 'tc_smoothscroll') ) );
       $smooth_scroll_options = apply_filters('tc_smoothscroll_options', array() );
@@ -228,7 +235,7 @@ if ( ! class_exists( 'TC_resources' ) ) :
 	          	'centerSliderImg'   => esc_attr( TC_utils::$inst->tc_opt( 'tc_center_slider_img') ),
               'SmoothScroll'      => array( 'Enabled' => $smooth_scroll_enabled, 'Options' => $smooth_scroll_options ),
               'anchorSmoothScroll'			=> $anchor_smooth_scroll,
-              'anchorSmoothScrollExclude' => apply_filters( 'tc_anchor_smoothscroll_excl' , array( '[class*=edd]' , '.tc-carousel-control', '.carousel-control', '[data-toggle="modal"]', '[data-toggle="dropdown"]', '[data-toggle="tooltip"]', '[data-toggle="popover"]', '[data-toggle="collapse"]', '[data-toggle="tab"]', '[class*=upme]', '[class*=um-]' ) ),
+              'anchorSmoothScrollExclude' => $anchor_smooth_scroll_exclude,
 	          	'ReorderBlocks' 		=> esc_attr( TC_utils::$inst->tc_opt( 'tc_block_reorder') ),
 	          	'centerAllImg' 			=> esc_attr( TC_utils::$inst->tc_opt( 'tc_center_img') ),
 	          	'HasComments' 			=> $has_post_comments,


### PR DESCRIPTION
…enabled

Fixes issue #258
This PR basically reproduce the code used in jqueryextLinks plugin to
check wheter or not a selector is allowed in the czrapp base code.
The new Smooth Scroll on click will work on:
a) (preliminary exclusion)
all the links which start with "#", except the ones specified in the
localized param anchorSmoothScrollExclude.simple (using jQuery.not)
b) (deep exclusion)
all the links which passed the preliminary exclusion and which do not
match the deep exclusion clauses on id and class - specified in the
param anchorSmoothScrollExclude.deep - using the method isSelectorAllowed.
The method isSelectorAllowed allow us to filter all the elements with a
parent matching the exclusion clauses on id and class.

This way we can exclude woocommerce's product tabs children of an
element with class 'wc-tabs'

p.s.
Since jqueryextLinks.js is a more general library (we can consider it external) 
I left the original code there with a call to the new czrapp method when czrapp 
exists, more to leave to you the decision on whether or not you want to 
remove the old code (to save some byte in tc-scripts.js) 