### PR TITLE
Fix: Add back the Google Font img in the Customizer

### DIFF
--- a/inc/admin/class-admin-customize.php
+++ b/inc/admin/class-admin-customize.php
@@ -380,7 +380,7 @@ if ( ! class_exists( 'TC_customize' ) ) :
 			wp_localize_script(
 		        'tc-customizer-preview',
 		        'TCPreviewParams',
-		        apply_filters('tc_js_customizer_control_params' ,
+		        apply_filters('tc_js_customizer_preview_params' ,
 			        array(
 			        	'themeFolder' 		=> get_template_directory_uri(),
                 //can be hacked to override the preview params when a custom skin is used

--- a/inc/admin/js/parts/_various_dom_ready.js
+++ b/inc/admin/js/parts/_various_dom_ready.js
@@ -55,7 +55,7 @@
 
     /* ADD GOOGLE IN TITLE */
     $g_logo = $('<img>' , {class : 'tc-title-google-logo' , src : 'http://www.google.com/images/logos/google_logo_41.png' , height : 20 });
-    $('#accordion-section-tc_fonts').prepend($g_logo);
+    $('#accordion-section-fonts_sec').prepend($g_logo);
 
 
     /* CHECK */


### PR DESCRIPTION
fixes issue #285
Due to the theme's settings recent changes the font section id now
is 'accordion-section-fonts_sec' and not 'accordion-section-tc_fonts'

Also fix a typo in class-admin-customize.php where the preview params
filter was named 'tc_js_customizer_control_params' (as the one for the
control js) instead of 'tc_js_customizer_preview_params'