### PR TITLE
Fix: allow customizr framework to generate addons default options

### DIFF
--- a/inc/admin/class-admin-customize.php
+++ b/inc/admin/class-admin-customize.php
@@ -294,12 +294,9 @@ if ( ! class_exists( 'TC_customize' ) ) :
           //all customizr theme options start by "tc_" by convention
           //=> footer customizer addon starts by fc_
           //=> grid customizer addon starts by gc_
+          //When do we add a prefix ?
           $add_prefix = false;
-          if ( 'tc_' === substr( $key, 0, 3 ) )
-            $add_prefix = true;
-          if ( 'gc_' === substr( $key, 0, 3 ) )
-            $add_prefix = true;
-          if ( 'fc_' === substr( $key, 0, 3 ) )
+          if ( TC_utils::$inst -> tc_is_customizr_option( $key ) )
             $add_prefix = true;
           $_opt_name = $add_prefix ? "{$tc_option_group}[{$key}]" : $key;
 

--- a/inc/class-fire-utils.php
+++ b/inc/class-fire-utils.php
@@ -21,6 +21,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
       public $db_options;
       public $options;//not used in customizer context only
       public $is_customizing;
+      public $tc_options_prefixes;
 
       function __construct () {
         self::$inst =& $this;
@@ -65,6 +66,8 @@ if ( ! class_exists( 'TC_utils' ) ) :
       * @since Customizr 3.2.3
       */
       function tc_init_properties() {
+        //all customizr theme options start by "tc_" by convention
+        $this -> tc_options_prefixes = apply_filters('tc_options_prefixes', array('tc_') );
         $this -> is_customizing   = TC___::$instance -> tc_is_customizing();
         $this -> db_options       = false === get_option( TC___::$tc_option_group ) ? array() : (array)get_option( TC___::$tc_option_group );
         $this -> default_options  = $this -> tc_get_default_options();
@@ -177,6 +180,22 @@ if ( ! class_exists( 'TC_utils' ) ) :
 
 
 
+      /**
+      * Helper
+      * Returns wheter or not the option is a theme/addon option
+      *
+      * @return bool
+      *
+      * @package Customizr
+      * @since Customizr 3.4.9
+      */
+      function tc_is_customizr_option( $option_key ) {
+        $_is_tc_option = in_array( substr( $option_key, 0, 3 ), $this -> tc_options_prefixes ); 
+        return apply_filters( 'tc_is_customizr_option', $_is_tc_option , $option_key );       
+      }
+
+
+
      /**
       * Returns the default options array
       *
@@ -228,8 +247,7 @@ if ( ! class_exists( 'TC_utils' ) ) :
 
         foreach ($map['add_setting_control'] as $key => $options) {
           //check it is a customizr option
-          //all customizr theme options start by "tc_" by convention
-          if(  'tc_' !== substr( $key, 0, 3 ) )
+          if(  ! $this -> tc_is_customizr_option( $key ) )
             continue;
 
           $option_name = $key;


### PR DESCRIPTION
- in class-fire-utils:
  - declare an array attribute, filterable, which
  stores the allowed prefixes ('tc_' for common customizr options)
  - new public method tc_is_customizr_option will check wheter or not
    the option with the passed key should be taken in account. The
    return of this method is filtered to allow addons using a different
    way to check the eligibility
  - tc_generate_default_options will use the above method to generate
    default options for the allowed keys
- in class-admin-customize the method tc_customize_factory will use the
  TC_utils method tc_is_customizr_option to check whether or not the
  option needs to be prefixed with the theme option group prefix