### PR TITLE
Imp: allow contextual doc link in the customizer info

### DIFF
--- a/inc/admin/class-admin-customize.php
+++ b/inc/admin/class-admin-customize.php
@@ -192,14 +192,16 @@ if ( ! class_exists( 'TC_customize' ) ) :
 								'description',
 								'priority' ,
 								'theme_supports',
-								'capability'
+                                'capability',
+                                'doc_link'
 					),
 					'sections' => array(
 								'title' ,
 								'priority' ,
 								'description',
 								'panel',
-								'theme_supports'
+                                'theme_supports',
+                                'doc_link'
 					),
 					'settings' => array(
 								'default'			=>	null,
@@ -245,7 +247,14 @@ if ( ! class_exists( 'TC_customize' ) ) :
 		 * @since Customizr 3.0
 		 */
 		function tc_customize_factory ( $wp_customize , $args, $setup ) {
-			global $wp_version;
+            global $wp_version;
+            $doc_link_message = __( "Check the theme's %sdocumentation%s", 'customizr');
+            $doc_link_message = sprintf( '<br><p class="tc-doc-link-container">%1$s</p>',
+                sprintf( $doc_link_message,
+                    '<a class="tc-doc-link" target="_blank" href="%1$s">',
+                    '</a>'
+                )
+            );
 			//add panels if current WP version >= 4.0
 			if ( isset( $setup['add_panel']) && version_compare( $wp_version, '4.0', '>=' ) ) {
 				foreach ( $setup['add_panel'] as $p_key => $p_options ) {
@@ -254,7 +263,10 @@ if ( ! class_exists( 'TC_customize' ) ) :
 					//checks authorized panel args
 					foreach( $args['panels'] as $p_set) {
 						$panel_options[$p_set] = isset( $p_options[$p_set]) ?  $p_options[$p_set] : null;
-					}
+                    }
+                    if ( isset( $panel_options['doc_link'] ) && ( isset( $panel_options['description'] ) ) )
+                      $panel_options['description'] .= sprintf( $doc_link_message, esc_url( $panel_options['doc_link']) );
+
 					$wp_customize -> add_panel( $p_key, $panel_options );
 				}
 			}
@@ -275,6 +287,8 @@ if ( ! class_exists( 'TC_customize' ) ) :
 					foreach( $args['sections'] as $sec) {
 						$option_section[$sec] = isset( $options[$sec]) ?  $options[$sec] : null;
 					}
+                    if ( isset( $option_section['doc_link'] ) && ( isset( $option_section['description'] ) ) )
+                      $option_section['description'] .= sprintf( $doc_link_message, esc_url( $option_section['doc_link']) );
 
 					//add section
 					$wp_customize	-> add_section( $key,$option_section);
@@ -520,7 +534,16 @@ if ( ! class_exists( 'TC_customize' ) ) :
     *@since v3.2.9
     */
     function tc_print_js_templates() {
+      $doc_link_message = __( "Check the theme's %sdocumentation%s", 'customizr');
+      $doc_link_message = sprintf( '<br><p class="tc-doc-link-container">%1$s</p>',
+      sprintf( $doc_link_message,
+          '<a class="tc-doc-link" target="_blank" href="%1$s">',
+          '</a>'
+      ));   
       ?>
+      <script type="text/template" id="customizr-doc-link">
+        <?php printf($doc_link_message, esc_url('http://docs.presscustomizr.com') ) ?>
+      </script>
       <script type="text/template" id="donate_template">
         <div id="tc-donate-customizer">
           <a href="#" class="tc-close-request button" title="<?php _e('dismiss' , 'customizr'); ?>">X</a>

--- a/inc/admin/js/parts/_various_dom_ready.js
+++ b/inc/admin/js/parts/_various_dom_ready.js
@@ -136,6 +136,15 @@
     /* NUMBER */
     $('input[type="number"]').stepper();
 
+    //templates rendering
+    _render_doc_link();
+    
+    function _render_doc_link(){
+      var $_doc_link = _.template(
+        $( "script#customizr-doc-link" ).html()
+      );
+      $('#customize-info > .customize-panel-description').append( $_doc_link );
+    }
   });//end of $( function($) ) dom ready
 
 })( wp, jQuery);

--- a/inc/class-fire-utils_settings_map.php
+++ b/inc/class-fire-utils_settings_map.php
@@ -2144,7 +2144,8 @@ if ( ! class_exists( 'TC_utils_settings_map' ) ) :
                   'priority'       => 10,
                   'capability'     => 'edit_theme_options',
                   'title'          => __( 'Global settings' , 'customizr' ),
-                  'description'    => __( "Global settings for the Customizr theme :skin, socials, links..." , 'customizr' )
+                  'description'    => __( "Global settings for the Customizr theme :skin, socials, links..." , 'customizr' ),
+                  'doc_link'       => 'http://docs.presscustomizr.com/article/100-customizr-theme-options-global-settings'
         ),
         'tc-header-panel' => array(
                   'priority'       => 20,


### PR DESCRIPTION
About #560 
What do you think?
Of course you can put the whole html code in the description field in utils_settings_map.
But I preferred this way so to keep the filling of the panel/settings map more focused on "simple" parameters.
