### PR TITLE
Fix: fix superfluous bracket in font-awesome icons inline style

### DIFF
--- a/inc/_dev/class-fire-resources.php
+++ b/inc/_dev/class-fire-resources.php
@@ -362,7 +362,7 @@ if ( ! class_exists( 'CZR_resources' ) ) :
         ?>
         @font-face {
           font-family: 'FontAwesome';
-          src:url('<?php echo $_path ?>/fonts/fonts/fontawesome-webfont.eot<?php echo $_query_var ?>' ) );
+          src:url('<?php echo $_path ?>/fonts/fonts/fontawesome-webfont.eot<?php echo $_query_var ?>' );
           src:url('<?php echo $_path ?>/fonts/fonts/fontawesome-webfont.eot?#iefix<?php echo $_ie_query_var ?>') format('embedded-opentype'),
               url('<?php echo $_path ?>/fonts/fonts/fontawesome-webfont.woff2<?php echo $_query_var ?>') format('woff2'),
               url('<?php echo $_path ?>/fonts/fonts/fontawesome-webfont.woff<?php echo $_query_var ?>') format('woff'),


### PR DESCRIPTION
fixes #739