### PR TITLE
Fix: compatibility issue with PHP<5.5

### DIFF
--- a/inc/_dev/init.php
+++ b/inc/_dev/init.php
@@ -438,7 +438,8 @@ if ( ! function_exists( 'czr_fn_checked' ) ) {
 */
 if ( ! function_exists( 'czr_fn_has_social_links' ) ) {
   function czr_fn_has_social_links() {
-    return ! empty ( czr_fn_get_opt('tc_social_links') );
+    $_socials = czr_fn_get_opt('tc_social_links');
+    return ! empty( $_socials );
   }
 }
 


### PR DESCRIPTION
http://php.net/manual/en/function.empty.php
Prior to PHP 5.5, empty() only supports variables; anything else will
result in a parse error.