### PR TITLE
Fix: fix btn-toggle-nav position on sticky-enabled when tagline-off

### DIFF
--- a/inc/assets/less/tc_custom_responsive.less
+++ b/inc/assets/less/tc_custom_responsive.less
@@ -115,7 +115,11 @@
   body .tc-header .btn-toggle-nav.pull-right {
     clear: both;
   }
-  /* if only socials + btn-nav in navbar (no tagline), do not drop on a new line */
+  /* do not drop on a new line if:
+  - only socials + btn-nav in navbar (no tagline), do not drop on a new line when sticky disabled 
+  - tagline-off (socials are never displayed as of now) when sticky enabled
+  */
+  .sticky-enabled .tc-tagline-off .btn-toggle-nav.pull-right,
   body:not(.sticky-enabled) .tc-header .social-block + .btn-toggle-nav.pull-right {
     clear: none;
   }


### PR DESCRIPTION
Otherwise you won't have the btn next to the cart when sticky-enabled like in the demo.