### PR TITLE
Fix: for czr4 alpha testing always fire the customizer in dev/debug mode

### DIFF
--- a/core/czr/class-czr-resources.php
+++ b/core/czr/class-czr-resources.php
@@ -20,8 +20,8 @@ if ( ! class_exists( 'CZR_customize_resources' ) ) :
     function __construct () {
       self::$instance =& $this;
 
-      $this->_is_debug_mode = ( defined('WP_DEBUG') && true === WP_DEBUG );
-      $this->_is_dev_mode   = ( defined('CZR_DEV') && true === CZR_DEV );
+      $this->_is_debug_mode = true;//set to true in beta ( defined('WP_DEBUG') && true === WP_DEBUG );
+      $this->_is_dev_mode   = true;//set to true in beta ( defined('CZR_DEV') && true === CZR_DEV );
 
       //control scripts and style
       add_action( 'customize_controls_enqueue_scripts'        , array( $this, 'czr_fn_customize_controls_js_css' ), 10 );


### PR DESCRIPTION
czr4 customizer concatenated js are not built, they are in a very early stage, let's be sure we always enqueue the dev files.