### PR TITLE
Fix: typo producing Class 'CZR__' not found in classical retro compat

### DIFF
--- a/inc/_dev/class-fire-init_retro_compat.php
+++ b/inc/_dev/class-fire-init_retro_compat.php
@@ -81,7 +81,7 @@ if ( ! class_exists( 'CZR_init_retro_compat' ) ) :
         return array();
       }
 
-      $_old_socials          = CZR__::$instance -> old_socials;
+      $_old_socials          = CZR___::$instance -> old_socials;
       $_old_filtered_socials = apply_filters( 'tc_default_socials', $_old_socials );
 
       /*


### PR DESCRIPTION
fixes #972