### PR TITLE
Fix: classic - fix non existing function as __ID filter callback

### DIFF
--- a/inc/_dev/class-fire-utils.php
+++ b/inc/_dev/class-fire-utils.php
@@ -41,7 +41,7 @@ if ( ! class_exists( 'CZR_utils' ) ) :
         add_filter( '__get_option'            , 'czr_fn_opt' , 10, 2 );//deprecated
 
         //some useful filters
-        add_filter( '__ID'                    , 'czr_fn_id' );//deprecated
+        add_filter( '__ID'                    , 'czr_fn_get_id' );//deprecated
         add_filter( '__screen_layout'         , array( $this , 'czr_fn_get_layout' ) , 10 , 2 );//deprecated
         add_filter( '__is_home'               , 'czr_fn_is_home' );
         add_filter( '__is_home_empty'         , 'czr_fn_is_home_empty' );


### PR DESCRIPTION
czr_fn_id should be replaced by czr_fn_get_id.
czr_fn_id exists only as static (deprecated) method of the classic
CZR_utils class