### PR TITLE
Imp: modern - do not use czr_fn_render_template anymore for some elem…

### DIFF
--- a/core/class-fire-plugins_compat.php
+++ b/core/class-fire-plugins_compat.php
@@ -1220,19 +1220,12 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
     /* no archive headings */
     function czr_fn_mainwrapper_start() {
 
-      /* SLIDERS : standard or slider of posts */
-      if ( czr_fn_is_registered_or_possible('main_slider') ) {
-        czr_fn_render_template( 'modules/slider/slider', array( 'model_id' => 'main_slider') );
-      }
-
-      elseif( czr_fn_is_registered_or_possible( 'main_posts_slider' ) ) {
-        czr_fn_render_template( 'modules/slider/slider', array( 'model_id' => 'main_posts_slider') );
-      }
-
-
-      do_action('__before_main_wrapper');
-
+        // This hook is used to render the following elements(ordered by priorities) :
+        // slider
+        // singular thumbnail
+        do_action('__before_main_wrapper')
       ?>
+
       <div id="main-wrapper" class="section">
 
 
@@ -1258,19 +1251,13 @@ if ( ! class_exists( 'CZR_plugins_compat' ) ) :
           </div>
         <?php endif ?>
 
-        <?php do_action('__before_main_container') ?>
-
         <?php
-          /* FEATURED PAGES */
-          if ( czr_fn_is_registered_or_possible( 'featured_pages' ) )
-            czr_fn_render_template( 'modules/featured-pages/featured_pages' );
+          /*
+          * Featured Pages | 10
+          * Breadcrumbs | 20
+          */
+          do_action('__before_main_container')
         ?>
-
-        <?php if ( czr_fn_is_registered_or_possible('breadcrumb') ) : ?>
-          <div class="container">
-            <?php czr_fn_render_template( 'modules/common/breadcrumb' ) ?>
-          </div>
-        <?php endif ?>
 
 
         <div class="<?php czr_fn_main_container_class() ?>" role="main">

--- a/core/front/models/class-model-main_content.php
+++ b/core/front/models/class-model-main_content.php
@@ -29,18 +29,48 @@ class CZR_main_content_model_class extends CZR_Model {
                   /* Need to be registered before rendering because of the custom style*/
                   array(
 
-                        'model_class' => 'modules/slider/slider',
-                        'id'          => 'main_slider'
+                        'template'    => 'modules/slider/slider',
+                        'id'          => 'main_slider',
+                        'hook'        => '__before_main_wrapper',
+                        'priority'    => 10
 
                   ),
                   //slider of posts
                   array(
 
                         'id'          => 'main_posts_slider',
-                        'model_class' => array( 'parent' => 'modules/slider/slider', 'name' => 'modules/slider/slider_of_posts' )
-
+                        'model_class' => array( 'parent' => 'modules/slider/slider', 'name' => 'modules/slider/slider_of_posts' ),
+                        'template'    => 'modules/slider/slider',
+                        'hook'        => '__before_main_wrapper',
+                        'priority'    => 10
                   ),
+
                   /** end slider **/
+
+                  /*********************************************
+                  * Featured Pages
+                  *********************************************/
+                  /* contains the featured page item registration */
+                  array(
+                        'id'          => 'featured_pages',
+                        'template'    => 'modules/featured-pages/featured_pages',
+                        'hook'        => '__before_main_container',
+                        'priority'    => 10
+                  ),
+                  /** end featured pages **/
+
+                  /*********************************************
+                  * Breadcrumbs
+                  *********************************************/
+                  /* contains the featured page item registration */
+                  array(
+                        'id'          => 'breadcrumb',
+                        'template'    => 'modules/common/breadcrumb',
+                        'hook'        => '__before_main_container',
+                        'priority'    => 20
+                  ),
+                  /** end featured pages **/
+
 
                   /* Needs to access the czr_user_options_style */
                   /*********************************************
@@ -119,6 +149,7 @@ class CZR_main_content_model_class extends CZR_Model {
                         //slider full when __before_main_wrapper otherwise take the original one
                         'thumb_size'               => '__before_main_wrapper' == $_hook ? 'slider-full' : null
                   ),
+                  'priority'   => 15,
                   'controller' => 'singular_thumbnail'
             ) );
 

--- a/core/front/models/modules/common/class-model-breadcrumb.php
+++ b/core/front/models/modules/common/class-model-breadcrumb.php
@@ -15,7 +15,8 @@
 */
 
 class CZR_breadcrumb_model_class extends CZR_Model {
-  public $breadcrumb;
+  public  $breadcrumb;
+
   private $_args;
 
   function czr_fn_extend_params( $model = array() ) {
@@ -41,14 +42,15 @@ class CZR_breadcrumb_model_class extends CZR_Model {
 
   function _get_args() {
     $args =  array(
-      'container'  => 'nav' , // div, nav, p, etc.
-      'separator'  => !is_rtl() ? '&raquo;' : '&laquo;' ,
-      'before'     => false,
-      'after'      => false,
-      'front_page' => true,
-      'show_home'  => __( 'Home' , 'customizr' ),
-      'network'    => false,
-      'echo'       => false
+      'container'       => 'nav' , // div, nav, p, etc.
+      'container_class' => 'col-12',
+      'separator'       => !is_rtl() ? '&raquo;' : '&laquo;' ,
+      'before'          => false,
+      'after'           => false,
+      'front_page'      => true,
+      'show_home'       => __( 'Home' , 'customizr' ),
+      'network'         => false,
+      'echo'            => false,
     );
 
     /* Set up the default arguments for the breadcrumb. */
@@ -119,7 +121,7 @@ class CZR_breadcrumb_model_class extends CZR_Model {
     if ( !empty( $trail ) && is_array( $trail ) ) {
 
       /* Open the breadcrumb trail containers. */
-      $breadcrumb = '<' . tag_escape( $args['container'] ) . ' class="breadcrumbs" itemprop="breadcrumb">';
+      $breadcrumb = '<' . tag_escape( $args['container'] ) . ' class="breadcrumbs ' . $args[ 'container_class' ] . '" itemprop="breadcrumb">';
 
       /* If $before was set, wrap it in a container. */
       $breadcrumb .= ( !empty( $args['before'] ) ? '<span class="trail-before">' . $args['before'] . '</span> ' : '' );

--- a/core/init.php
+++ b/core/init.php
@@ -341,15 +341,6 @@ if ( ! class_exists( 'CZR___' ) ) :
                     'id'             => 'header'
                   ),
 
-                  /*********************************************
-                  * Featured Pages
-                  *********************************************/
-                  /* contains the featured page item registration */
-                  array(
-                    'id'          => 'featured_pages',
-                    'model_class' => 'modules/featured-pages/featured_pages',
-                  ),
-                  /** end featured pages **/
 
                   /*********************************************
                   * CONTENT

--- a/templates/index-no-model.php
+++ b/templates/index-no-model.php
@@ -14,20 +14,10 @@
 ?>
 <?php get_header() ?>
 
-  <?php
-    /* SLIDERS : standard or slider of posts */
-    if ( czr_fn_is_registered_or_possible('main_slider') ) {
-      czr_fn_render_template( 'modules/slider/slider', array( 'model_id' => 'main_slider') );
-    }
-
-    elseif( czr_fn_is_registered_or_possible( 'main_posts_slider' ) ) {
-      czr_fn_render_template( 'modules/slider/slider', array( 'model_id' => 'main_posts_slider') );
-    }
-
-  ?>
 
   <?php
     // This hook is used to render the following elements(ordered by priorities) :
+    // slider
     // singular thumbnail
     do_action('__before_main_wrapper')
   ?>
@@ -56,20 +46,13 @@
           <?php endif ?>
 
 
-          <?php do_action('__before_main_container') ?>
-
           <?php
-            /* FEATURED PAGES */
-            if ( czr_fn_is_registered_or_possible( 'featured_pages' ) )
-              czr_fn_render_template( 'modules/featured-pages/featured_pages' );
+            /*
+            * Featured Pages | 10
+            * Breadcrumbs | 20
+            */
+            do_action('__before_main_container')
           ?>
-
-          <?php if ( czr_fn_is_registered_or_possible('breadcrumb') ) : ?>
-            <div class="container">
-              <?php czr_fn_render_template( 'modules/common/breadcrumb' ) ?>
-            </div>
-          <?php endif ?>
-
 
           <div class="<?php czr_fn_main_container_class() ?>" role="main">
 

--- a/templates/parts/modules/common/breadcrumb.php
+++ b/templates/parts/modules/common/breadcrumb.php
@@ -6,8 +6,8 @@
  * @since Customizr 3.5.0
  */
 ?>
-<div class="czr-hot-crumble row page-breadcrumbs" role="navigation" <?php czr_fn_echo('element_attributes') ?>>
-  <div class="col-12">
+<div class="czr-hot-crumble container page-breadcrumbs" role="navigation" <?php czr_fn_echo('element_attributes') ?>>
+  <div class="row">
     <?php /* or do not use a model but a tc function (template tag) */ ?>
     <?php czr_fn_echo( 'breadcrumb' ) ?>
   </div>


### PR DESCRIPTION
…ents

like:
slider
fp
breadcrumbs

they'll be registered in the main_content model using the hook param