### PR TITLE
Imp: modern - remove __before/__after_modelid comments in fmk view

### DIFF
--- a/core/_dev/_framework/class-view.php
+++ b/core/_dev/_framework/class-view.php
@@ -67,7 +67,8 @@ if ( ! class_exists( 'CZR_View' ) ) :
         $czr_fn_print_debug =  ! czr_fn_is_customizing() && is_user_logged_in() && current_user_can( 'edit_theme_options' );
 
         if ( $czr_fn_print_debug ) {
-            echo "<!-- HOOK CONTENT HERE : __before_{$this -> model -> id} -->";
+            //since we don't trigger the __before_{$this->model->id} action anymore we don't have to print this
+            //echo "<!-- HOOK CONTENT HERE : __before_{$this -> model -> id} -->";
             echo "<!-- START RENDERING VIEW ID : {$this -> model -> id} -->";
         }
 
@@ -83,7 +84,8 @@ if ( ! class_exists( 'CZR_View' ) ) :
 
         if ( $czr_fn_print_debug ) {
             echo "<!-- END OF RENDERING VIEW ID : {$this -> model -> id} -->";
-            echo "<!-- HOOK CONTENT HERE : __after_{$this -> model -> id} -->";
+              //since we don't trigger the __after_{$this->model->id} action anymore we don't have to print this
+            //echo "<!-- HOOK CONTENT HERE : __after_{$this -> model -> id} -->";
         }
         //do_action( "__after_{$this -> model -> id}" ); <= DO WE REALLY NEED THOSE ?
 


### PR DESCRIPTION
as we don't trigger those actions anymore