### PR TITLE
Fix: modern - fix first-child pseudo selector syntax

### DIFF
--- a/assets/front/scss/0_3_components/_components.scss
+++ b/assets/front/scss/0_3_components/_components.scss
@@ -510,7 +510,7 @@ cite {
     left:0;
     background: $black;
   }
-  &::first-child {
+  &:first-child {
     float: left
   }
 }


### PR DESCRIPTION
when building the rtl min made it's following selector
and the whole rule not working
fixes #1159