### PR TITLE
Fix: fix menu centered wrongly displayed in ie/edge

### DIFF
--- a/templates/parts/header/parts/nav_container.php
+++ b/templates/parts/header/parts/nav_container.php
@@ -6,7 +6,7 @@
 <div class="primary-nav__container <?php czr_fn_echo('element_class') ?>" <?php czr_fn_echo('element_attributes') ?>>
   <div class="primary-nav__wrapper flex-lg-row align-items-center justify-content-end">
      <?php if ( czr_fn_is_registered_or_possible( 'navbar_primary_menu' ) || czr_fn_is_registered_or_possible( 'navbar_secondary_menu' ) ) { ?>
-         <nav class="primary-nav__nav col-lg" id="primary-nav">
+         <nav class="primary-nav__nav col col-auto" id="primary-nav">
           <?php
               czr_fn_render_template( 'header/parts/menu', array(
                 'model_id'   =>  czr_fn_is_registered_or_possible( 'navbar_primary_menu' ) ? 'navbar_primary_menu' : 'navbar_secondary_menu',


### PR DESCRIPTION
use more proper column classes for the primary-nav__nav element
fixes #1163 