### PR TITLE
Fix: fix slider textual fields wrong truncation

### DIFF
--- a/core/_dev/_admin/class-admin-meta_boxes.php
+++ b/core/_dev/_admin/class-admin-meta_boxes.php
@@ -1158,13 +1158,7 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
          if(!in_array( 'slide_title_key' ,get_post_custom_keys( $postid))) {
            $title_value = $default_title;
          }
-         if (strlen( $title_value) > $default_title_length) {
-           $title_value = substr( $title_value,0,strpos( $title_value, ' ' , $default_title_length));
-           $title_value = esc_html( $title_value) . ' ...';
-         }
-         else {
-           $title_value = esc_html( $title_value);
-         }
+         $title_value = esc_html( czr_fn_text_truncate( $title_value, $default_title_length, '...' ) );
 
 
          //text_field setup : sanitize and limit length
@@ -1176,14 +1170,8 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
           //check if we already have a custom key created for this field, if not apply default value
          if(!in_array( 'slide_text_key' ,get_post_custom_keys( $postid)))
            $text_value = $default_description;
+         $text_value = czr_fn_text_truncate( $text_value, $default_text_length, '...' );
 
-         if (strlen( $text_value) > $default_text_length) {
-           $text_value = substr( $text_value,0,strpos( $text_value, ' ' ,$default_text_length));
-           $text_value = $text_value . ' ...';
-         }
-         else {
-           $text_value = $text_value;
-         }
 
           //Color field setup
          $color_id       = 'slide_color_field';
@@ -1192,16 +1180,12 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
          //button field setup
          $button_id      = 'slide_button_field';
          $button_value   = esc_attr(get_post_meta( $postid, $key = 'slide_button_key' , $single = true ));
+
          //we define a filter for the slide text_button length
          $default_button_length   = apply_filters( 'czr_slide_button_length', 80 );
+         $button_value   = czr_fn_text_truncate( $button_value, $default_button_length, '...' );
 
-         if (strlen( $button_value) > $default_button_length) {
-           $button_value = substr( $button_value,0,strpos( $button_value, ' ' ,$default_button_length));
-           $button_value = $button_value . ' ...';
-         }
-         else {
-           $button_value = $button_value;
-         }
+
 
          //link field setup
          $link_id        = 'slide_link_field';
@@ -1419,18 +1403,23 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
            foreach ( $tc_slider_fields as $tcid => $tckey) {
                if ( isset( $_POST[$tcid])) {
                  $mydata = sanitize_text_field( $_POST[$tcid] );
+
                   switch ( $tckey) {
                     //different sanitizations
                     case 'slide_text_key':
                         $default_text_length = apply_filters( 'czr_slide_text_length', 250 );
-                        if (strlen( $mydata) > $default_text_length) {
-                          $mydata = substr( $mydata,0,strpos( $mydata, ' ' ,$default_text_length));
-                          $mydata = esc_html( $mydata) . ' ...';
-                        }
-                        else {
-                          $mydata = esc_html( $mydata);
-                        }
-                      break;
+                        $mydata = esc_html( czr_fn_text_truncate( $mydata, $default_text_length, '...' ) );
+                    break;
+
+                    case 'slide_title_key':
+                        $default_title_length = apply_filters( 'czr_slide_title_length', 80 );
+                        $mydata = esc_html( czr_fn_text_truncate( $mydata, $default_title_length, '...' ) );
+                    break;
+
+                    case 'slide_button_key':
+                        $default_button_text_length = apply_filters( 'czr_slide_button_length', 80 );
+                        $mydata = esc_html( czr_fn_text_truncate( $mydata, $default_button_text_length, '...' ) );
+                    break;
 
                     case 'slide_custom_link_key':
                         $mydata = esc_url( $_POST[$tcid] );
@@ -1441,15 +1430,8 @@ if ( ! class_exists( 'CZR_meta_boxes' ) ) :
                         $mydata = esc_attr( $mydata );
                     break;
 
-                    default://for button, color, title and post link field (actually not a link but an id)
-                        $default_title_length = apply_filters( 'czr_slide_title_length', 80 );
-                       if (strlen( $mydata) > $default_title_length) {
-                        $mydata = substr( $mydata,0,strpos( $mydata, ' ' , $default_title_length));
-                        $mydata = esc_attr( $mydata) . ' ...';
-                        }
-                        else {
-                          $mydata = esc_attr( $mydata);
-                        }
+                    default://for color, post link field (actually not a link but an id)
+                        $mydata = esc_attr( $mydata );
                       break;
                   }//end switch
                  //write in DB

--- a/core/core-functions.php
+++ b/core/core-functions.php
@@ -1527,3 +1527,38 @@ function czr_fn_booleanize_checkbox_val( $val ) {
       default : return false;
     }
 }
+
+if ( ! function_exists( 'czr_fn_text_truncate' ) ):
+  /**
+  * Helper
+  * Returns the passed text truncated at $text_length char.
+  * with the $more text added
+  *
+  * @return string
+  *
+  */
+  function czr_fn_text_truncate( $text, $max_text_length, $more, $strip_tags = true ) {
+      if ( ! $text )
+          return '';
+
+      if ( $strip_tags )
+        $text       = strip_tags( $text );
+      
+      if ( ! $max_text_length )
+          return $text;
+
+      $end_substr = $text_length = strlen( $text );
+      if ( $text_length > $max_text_length ) {
+          $text      .= ' ';
+          $end_substr = strpos( $text, ' ' , $max_text_length);
+          $end_substr = ( FALSE !== $end_substr ) ? $end_substr : $max_text_length;
+          $text       = trim( substr( $text , 0 , $end_substr ) );
+      }
+
+      if ( $more && $end_substr < $text_length )
+        return $text . ' ' .$more;
+
+      return $text;
+    
+  }
+endif;

--- a/core/front/models/modules/featured-pages/class-model-featured_pages.php
+++ b/core/front/models/modules/featured-pages/class-model-featured_pages.php
@@ -173,8 +173,7 @@ class CZR_featured_pages_model_class extends CZR_Model {
 
         //limit text to 200 car
           $default_fp_text_length         = apply_filters( 'czr_fp_text_length', $this->text_length, $fp_single_id, $featured_page_id );
-          $text                           = ( strlen($text) > $default_fp_text_length ) ? substr( $text , 0 , strpos( $text, ' ' , $default_fp_text_length) ). ' ...' : $text;
-
+          $text                           = czr_fn_text_truncate( $text, $default_fp_text_length, $more = '...', $strip_tags = false ); //tags already stripped
 
           if ( $show_thumb ) {
             //set the image : uses thumbnail if any then >> the first attached image then >> a holder script

--- a/core/front/models/modules/slider/class-model-slider.php
+++ b/core/front/models/modules/slider/class-model-slider.php
@@ -193,15 +193,15 @@ class CZR_slider_model_class extends CZR_Model {
     //title
     $title                  = esc_attr(get_post_meta( $id, $key = 'slide_title_key' , $single = true ));
     $default_title_length   = apply_filters( 'czr_slide_title_length', 80 );
-    $title                  = $this -> czr_fn_trim_text( $title, $default_title_length, '...' );
+    $title                  = czr_fn_text_truncate( $title, $default_title_length, '...' );
     //lead text
     $text                   = get_post_meta( $id, $key = 'slide_text_key' , $single = true );
     $default_text_length    = apply_filters( 'czr_slide_text_length', 250 );
-    $text                   = $this -> czr_fn_trim_text( $text, $default_text_length, '...' );
+    $text                   = czr_fn_text_truncate( $text, $default_text_length, '...' );
     //button text
     $button_text            = esc_attr(get_post_meta( $id, $key = 'slide_button_key' , $single = true ));
     $default_button_length  = apply_filters( 'czr_slide_button_length', 80 );
-    $button_text            = $this -> czr_fn_trim_text( $button_text, $default_button_length, '...' );
+    $button_text            = czr_fn_text_truncate( $button_text, $default_button_length, '...' );
     //link post id
     $link_id                = apply_filters( 'czr_slide_link_id', esc_attr(get_post_meta( $id, $key = 'slide_link_key' , $single = true )), $id, $slider_name_id );
     //link
@@ -603,32 +603,6 @@ class CZR_slider_model_class extends CZR_Model {
   }
 
 
-  /**
-  * Helper
-  * Returns the passed text trimmed at $text_length char.
-  * with the $more text added
-  *
-  * @return string
-  *
-  * @package Customizr
-  * @since Customizr 3.4.9
-  *
-  */
-  // move this into CZR_utils?
-  function czr_fn_trim_text( $text, $text_length, $more ) {
-    if ( ! $text )
-      return '';
-    $text       = trim( strip_tags( $text ) );
-    if ( ! $text_length )
-      return $text;
-    $end_substr = $_text_length = strlen( $text );
-    if ( $_text_length > $text_length ){
-      $end_substr = strpos( $text, ' ' , $text_length);
-      $end_substr = ( $end_substr !== FALSE ) ? $end_substr : $text_length;
-      $text = substr( $text , 0 , $end_substr );
-    }
-    return ( ( $end_substr < $text_length ) && $more ) ? $text : $text . ' ' .$more ;
-  }
 
   /**
   * hook : tc_slider_height, fired in czr_fn_user_options_style

--- a/core/front/models/modules/slider/class-model-slider_of_posts.php
+++ b/core/front/models/modules/slider/class-model-slider_of_posts.php
@@ -359,7 +359,7 @@ class CZR_slider_of_posts_model_class extends CZR_slider_model_class {
     $button_text_length  = apply_filters( 'czr_posts_slider_button_text_length', 80 );
     $more                = apply_filters( 'czr_post_slide_more', '...');
     $button_text         = apply_filters( 'czr_posts_slider_button_text_pre_trim' , $button_text );
-    return $this -> czr_fn_trim_text( $button_text, $button_text_length, $more );
+    return czr_fn_text_truncate( $button_text, $button_text_length, $more );
   }
 
   /**
@@ -383,7 +383,7 @@ class CZR_slider_of_posts_model_class extends CZR_slider_model_class {
       $title = sprintf( $protected_title_format, $title );
     }
     $title = apply_filters( 'czr_post_title_pre_trim' , $title );
-    return $this -> czr_fn_trim_text( $title, $default_title_length, $more);
+    return czr_fn_text_truncate( $title, $default_title_length, $more);
   }
 
   /**
@@ -415,6 +415,6 @@ class CZR_slider_of_posts_model_class extends CZR_slider_model_class {
     $excerpt = shortcode_unautop( $excerpt );
     $excerpt = str_replace(']]>', ']]&gt;', $excerpt );
     $excerpt = apply_filters( 'czr_post_excerpt_pre_trim' , $excerpt );
-    return $this -> czr_fn_trim_text( $excerpt, $default_text_length, $more);
+    return czr_fn_text_truncate( $excerpt, $default_text_length, $more);
   }
 }

--- a/inc/_dev/parts/class-content-featured_pages.php
+++ b/inc/_dev/parts/class-content-featured_pages.php
@@ -224,7 +224,8 @@ if ( ! class_exists( 'CZR_featured_pages' ) ) :
 
             //limit text to 200 car
             $default_fp_text_length         = apply_filters( 'tc_fp_text_length', 200, $fp_single_id, $featured_page_id );
-            $text                           = ( strlen($text) > $default_fp_text_length ) ? substr( $text , 0 , strpos( $text, ' ' , $default_fp_text_length) ). ' ...' : $text;
+            $text                           = czr_fn_text_truncate( $text, $default_fp_text_length, $more = '...', $strip_tags = false ); //tags already stripped
+
 
             //set the image : uses thumbnail if any then >> the first attached image then >> a holder script
             $fp_img_size                    = apply_filters( 'tc_fp_img_size' , 'tc-thumb', $fp_single_id, $featured_page_id );

--- a/inc/_dev/parts/class-content-slider.php
+++ b/inc/_dev/parts/class-content-slider.php
@@ -97,17 +97,17 @@ class CZR_slider {
     //title
     $title                  = esc_attr(get_post_meta( $id, $key = 'slide_title_key' , $single = true ));
     $default_title_length   = apply_filters( 'tc_slide_title_length', 80 );
-    $title                  = $this -> czr_fn_trim_text( $title, $default_title_length, '...' );
+    $title                  = czr_fn_text_truncate( $title, $default_title_length, '...' );
 
     //lead text
     $text                   = get_post_meta( $id, $key = 'slide_text_key' , $single = true );
     $default_text_length    = apply_filters( 'tc_slide_text_length', 250 );
-    $text                   = $this -> czr_fn_trim_text( $text, $default_text_length, '...' );
+    $text                   = czr_fn_text_truncate( $text, $default_text_length, '...' );
 
     //button text
     $button_text            = esc_attr(get_post_meta( $id, $key = 'slide_button_key' , $single = true ));
     $default_button_length  = apply_filters( 'tc_slide_button_length', 80 );
-    $button_text            = $this -> czr_fn_trim_text( $button_text, $default_button_length, '...' );
+    $button_text            = czr_fn_text_truncate( $button_text, $default_button_length, '...' );
 
     //link post id
     $link_id                = apply_filters( 'tc_slide_link_id', esc_attr(get_post_meta( $id, $key = 'slide_link_key' , $single = true )), $id, $slider_name_id );
@@ -1307,7 +1307,7 @@ class CZR_slider {
     $button_text_length  = apply_filters( 'tc_posts_slider_button_text_length', 80 );
     $more                = apply_filters( 'tc_post_slide_more', '...');
     $button_text         = apply_filters( 'tc_posts_slider_button_text_pre_trim' , $button_text );
-    return $this -> czr_fn_trim_text( $button_text, $button_text_length, $more );
+    return czr_fn_text_truncate( $button_text, $button_text_length, $more );
   }
 
   /**
@@ -1332,7 +1332,7 @@ class CZR_slider {
     }
 
     $title = apply_filters( 'tc_post_title_pre_trim' , $title );
-    return $this -> czr_fn_trim_text( $title, $default_title_length, $more);
+    return czr_fn_text_truncate( $title, $default_title_length, $more);
   }
 
 
@@ -1368,39 +1368,7 @@ class CZR_slider {
     $excerpt = str_replace(']]>', ']]&gt;', $excerpt );
 
     $excerpt = apply_filters( 'tc_post_excerpt_pre_trim' , $excerpt );
-    return $this -> czr_fn_trim_text( $excerpt, $default_text_length, $more);
-  }
-
-
-  /**
-  * Helper
-  * Returns the passed text trimmed at $text_length char.
-  * with the $more text added
-  *
-  * @return string
-  *
-  * @package Customizr
-  * @since Customizr 3.4.9
-  *
-  */
-  // move this into CZR_utils?
-  function czr_fn_trim_text( $text, $text_length, $more ) {
-    if ( ! $text )
-      return '';
-
-    $text       = trim( strip_tags( $text ) );
-
-    if ( ! $text_length )
-      return $text;
-
-    $end_substr = $_text_length = strlen( $text );
-
-    if ( $_text_length > $text_length ){
-      $end_substr = strpos( $text, ' ' , $text_length);
-      $end_substr = ( $end_substr !== FALSE ) ? $end_substr : $text_length;
-      $text = substr( $text , 0 , $end_substr );
-    }
-    return ( ( $end_substr < $text_length ) && $more ) ? $text : $text . ' ' .$more ;
+    return czr_fn_text_truncate( $excerpt, $default_text_length, $more);
   }
 
 } //end of class


### PR DESCRIPTION
fixes #1168

This issue also affected the featured pages.
With this commit we introduce czr_fn_text_truncate as shared function used by
slider and featured pages, so that we have the text truncation code in
one place only