### PR TITLE
Fix: classic - fix link whole slide not including the caption

### DIFF
--- a/inc/_dev/parts/class-content-slider.php
+++ b/inc/_dev/parts/class-content-slider.php
@@ -727,7 +727,7 @@ class CZR_slider {
   */
   function czr_fn_link_whole_slide( $slide_background, $link_url, $id, $slider_name_id, $data ) {
     if ( isset( $data['link_whole_slide'] )  && $data['link_whole_slide'] && $link_url )
-      $slide_background = sprintf('<a href="%1$s" class="tc-slide-link" target="%2$s" title="%3$s">%4$s</a>',
+      $slide_background = sprintf('<a href="%1$s" class="tc-slide-link" target="%2$s" title="%3$s"></a>%4$s',
                                 $link_url,
                                 $data['link_target'],
                                 __('Go to', 'customizr'),

--- a/inc/assets/less/tc_custom.less
+++ b/inc/assets/less/tc_custom.less
@@ -1489,11 +1489,20 @@ footer#footer .colophon .credits a[class*=icon-] {
 .carousel-caption .btn {
   margin-top: 10px;
 }
-
+/* link-whole-slide */
+.tc-slide-link {
+  z-index: 1;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+}
 .slider.edit-link {
   position: absolute;
   bottom: 40px;
   right: 11%;
+  z-index: 2;
 }
 .slider.deep-edit-link.edit-link {
   right: auto;


### PR DESCRIPTION
now this option behavior is consistent among classic and new style
fixes #1140