### PR TITLE
Fix: modern - fix fmk data attributes duplication

### DIFF
--- a/core/_dev/_framework/class-view.php
+++ b/core/_dev/_framework/class-view.php
@@ -66,11 +66,11 @@ if ( ! class_exists( 'CZR_View' ) ) :
 
         //ADD ATTRIBUTES TO THE WRAPPER
         /* Maybe merge debug info into the model element attributes */
-        $this -> model -> element_attributes =  join( ' ', array_filter( array(
-            $this -> model -> element_attributes,
+        $this -> model -> element_attributes = is_array( $this -> model -> element_attributes ) ? $this -> model -> element_attributes : explode( ' ', $this -> model -> element_attributes );
+        $this -> model -> element_attributes = join( ' ', array_filter( array_unique( array_merge( $this -> model -> element_attributes, array(
             'data-czr-model_id="'. $this -> model -> id .'"',
             isset( $this -> model -> template ) ? 'data-czr-template="templates/parts/'. $this -> model -> template .'"' : ''
-        )) );
+        )))) );
 
         $this -> czr_fn_render();
 


### PR DESCRIPTION
When using the same instance several times, you might end up
having something like this:
```
<li class="hamburger-toggler__container "
data-czr-model_id="menu_button"
data-czr-template="templates/parts/header/parts/menu_button"
data-czr-model_id="menu_button"
data-czr-template="templates/parts/header/parts/menu_button">
```