### PR TITLE
Fix: modern - fix label 'for' attribute referencing to no element

### DIFF
--- a/templates/parts/modules/search/searchform.php
+++ b/templates/parts/modules/search/searchform.php
@@ -6,9 +6,9 @@
 <div class="search-form__container <?php czr_fn_echo('element_class')?>" <?php czr_fn_echo('element_attributes')?>>
   <form action="<?php echo esc_url(home_url( '/' )); ?>" method="get" class="czr-form search-form">
     <div class="form-group czr-focus">
-      <?php $label_id = uniqid() ?>
-      <label for="s" id="search-<?php echo $label_id ?>"><span><?php _ex( 'Search', 'label', 'customizr') ?></span><i class="icn-search"></i><i class="icn-close"></i></label>
-      <input class="form-control czr-search-field" name="s" type="text" value="<?php echo get_search_query() ?>" aria-describedby="search-<?php echo $label_id ?>" title="<?php echo esc_attr_x( 'Search &hellip;', 'title', 'customizr') ?>">
+      <?php $sf_id = uniqid() ?>
+      <label for="s-<?php echo $sf_id ?>" id="lsearch-<?php echo $sf_id ?>"><span><?php _ex( 'Search', 'label', 'customizr') ?></span><i class="icn-search"></i><i class="icn-close"></i></label>
+      <input id="s-<?php echo $sf_id ?>" class="form-control czr-search-field" name="s" type="text" value="<?php echo get_search_query() ?>" aria-describedby="lsearch-<?php echo $sf_id ?>" title="<?php echo esc_attr_x( 'Search &hellip;', 'title', 'customizr') ?>">
     </div>
   </form>
 </div>


### PR DESCRIPTION
from: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label

for
The ID of a labelable form-related element in the same document as the
label element. The first such element in the document with an ID
matching the value of the for attribute is the labeled control for this
label element.