### PR TITLE
Add: customizer : add CZR_Customize_Code_Editor_Control

### DIFF
--- a/core/_dev/_czr/class-czr-init.php
+++ b/core/_dev/_czr/class-czr-init.php
@@ -78,6 +78,9 @@ if ( ! class_exists( 'CZR_customize' ) ) :
       if ( class_exists('CZR_Customize_Cropped_Image_Control') )
         $manager -> register_control_type( 'CZR_Customize_Cropped_Image_Control' );
 
+      if ( class_exists('CZR_Customize_Code_Editor_Control') )
+        $manager -> register_control_type( 'CZR_Customize_Code_Editor_Control' );
+
       if ( class_exists('CZR_Customize_Panels') )
         $manager -> register_panel_type( 'CZR_Customize_Panels');
 
@@ -353,7 +356,11 @@ if ( ! class_exists( 'CZR_customize' ) ) :
                 'dst_width',
                 'dst_height',
 
-                'ubq_section'
+                'ubq_section',
+
+                //for the code editor
+                'code_type',
+                'input_attrs'
 
           )
       );

--- a/core/_dev/_czr/controls/class-code-editor-control.php
+++ b/core/_dev/_czr/controls/class-code-editor-control.php
@@ -1,0 +1,51 @@
+<?php
+/*
+*/
+if ( class_exists('WP_Customize_Code_Editor_Control') && ! class_exists( 'CZR_Customize_Code_Editor_Control' ) ) :
+  class CZR_Customize_Code_Editor_Control extends WP_Customize_Code_Editor_Control {
+
+    public $type = 'czr_code_editor';
+    public $title;
+    public $notice;
+
+    /**
+     * Refresh the parameters passed to the JavaScript via JSON.
+     *
+     * @see WP_Customize_Control::json()
+     *
+     * @return array Array of parameters passed to the JavaScript.
+     */
+    public function json() {
+        $json = parent::json();
+        if ( is_array( $json ) ) {
+            $json['title']  = !empty( $this -> title )  ? esc_html( $this -> title ) : '';
+            $json['notice'] = !empty( $this -> notice ) ?           $this -> notice  : '';
+        }
+
+        return $json;
+    }
+
+
+    /**
+    * Render a JS template for the content of the media control.
+    *
+    * @since 3.4.19
+    * @package      Customizr
+    *
+    * @Override
+    * @see WP_Customize_Control::content_template()
+    */
+    public function content_template() {
+      ?>
+      <# if ( data.title ) { #>
+          <h3 class="czr-customizr-title">{{{ data.title }}}</h3>
+        <# } #>
+          <?php parent::content_template(); ?>
+        <# if ( data.notice ) { #>
+          <span class="czr-notice">{{{ data.notice }}}</span>
+        <# } #>
+      <?php
+    }
+  }//end class
+endif;
+?>


### PR DESCRIPTION
extends WP_Customize_Code_Editor_Control
as part of the fix for presscustomizr/pro-bundle#104