### PR TITLE
Fix: modern - apply margin-bottom to the mobile-nav__inner instead of

### DIFF
--- a/assets/front/scss/0_2_header/_headernav.scss
+++ b/assets/front/scss/0_2_header/_headernav.scss
@@ -388,7 +388,7 @@
   }
 
   //MORE SPACE AT THE BOTTOM WHEN EXPANDED
-  .nav__menu-wrapper {
+  .mobile-nav__inner {
      margin-bottom: 20px;
   }
 


### PR DESCRIPTION
the mobile-nav__menu-wrapper

as part of the fix for #1331