### PR TITLE
Fix: modern - remove unwanted vertical separator before comments link in

### DIFF
--- a/templates/parts/content/singular/headings/regular_post_heading.php
+++ b/templates/parts/content/singular/headings/regular_post_heading.php
@@ -60,12 +60,12 @@
 
             }
 
-            if ( $comment_info )
+            if ( ( $author || $date || $up_date ) && $comment_info )
               echo '<span class="v-separator">|</span>';
+        ?></span><?php
+        endif;
+        echo $comment_info;
         ?>
-          </span>
-        <?php endif ?>
-        <?php echo $comment_info; ?>
       </div>
     </div>
   </div>


### PR DESCRIPTION
single posts

fixes #1381