### PR TITLE
Imp: remove body itemprop itemtype structured data

### DIFF
--- a/header.php
+++ b/header.php
@@ -32,7 +32,7 @@ if ( apply_filters( 'czr_ms', false ) ) {
 		do_action( '__before_body' );
 	?>
 
-	<body <?php body_class(); ?> <?php echo apply_filters('tc_body_attributes' , 'itemscope itemtype="http://schema.org/WebPage"') ?>>
+	<body <?php body_class(); ?> <?php echo apply_filters('tc_body_attributes' , '') ?>>
 
     <?php do_action( '__before_page_wrapper' ); ?>
 

--- a/templates/header-no-model.php
+++ b/templates/header-no-model.php
@@ -19,7 +19,7 @@
 <!--<![endif]-->
   <?php czr_fn_require_once( CZR_MAIN_TEMPLATES_PATH . 'head-no-model.php' ) ?>
 
-  <body <?php body_class(); ?> itemscope itemtype="http://schema.org/WebPage">
+  <body <?php body_class(); ?>>
     <?php
         if ( czr_fn_is_registered_or_possible('sidenav') && czr_fn_is_registered_or_possible('header') ) {
           czr_fn_render_template( 'header/parts/sidenav' );


### PR DESCRIPTION
should fix issues with missing microformats reported by
the google-search-console in static pages:
https://github.com/presscustomizr/customizr/issues/1401
https://github.com/presscustomizr/customizr/issues/1344