### PR TITLE
Fix: modern - fix RTL breadcrumb separator displayed with wrong direc…

### DIFF
--- a/core/front/models/modules/common/class-model-breadcrumb.php
+++ b/core/front/models/modules/common/class-model-breadcrumb.php
@@ -44,7 +44,7 @@ class CZR_breadcrumb_model_class extends CZR_Model {
     $args =  array(
       'container'       => 'nav' , // div, nav, p, etc.
       'container_class' => 'col-12',
-      'separator'       => !is_rtl() ? '&raquo;' : '&laquo;' ,
+      'separator'       => '&raquo;',
       'before'          => false,
       'after'           => false,
       'front_page'      => true,


### PR DESCRIPTION
…tion

fixes #1420

This seems to happen only in the modern style. In classical we don't
actually use a different separator in RTL: always Â» (see
http://www.glezer.co.il/2017/08/%D7%A9%D7%9C%D7%9E%D7%94-%D7%A9%D7%9C%D7%9E%D7%94-%D7%A9%D7%9C%D7%9E%D7%94-%D7%A9%D7%9C%D7%9E%D7%94-%D7%A9%D7%9C%D7%9E%D7%94/)
Basically what happens is that the browsers, recognizing that the word
that precedes the Â« or Â» is a "RTL set of characters", automatically
rotates the Â« or Â».  I propose then to use the same separator (Â»)
both in LTR and RTL, as we do in the classical style.