### PR TITLE
Fix: modern - set word-wrap break-word for whatever text in #tc-page-…

### DIFF
--- a/assets/front/scss/0_1_base/_base.scss
+++ b/assets/front/scss/0_1_base/_base.scss
@@ -161,3 +161,6 @@ p {
 embed, iframe, object, video {
   max-width: 100%;
 }
+.clearfix {
+  @include clearfix();
+}

--- a/assets/front/scss/0_4_layout/_content.scss
+++ b/assets/front/scss/0_4_layout/_content.scss
@@ -3,6 +3,7 @@
   position: relative;
   background: inherit;
   z-index: 1;
+  word-wrap: break-word;
   &.czr-boxed {
     padding: 0;
     @include box-shadow( 0, 0, 10px, rgba(0,0,0,.2) );


### PR DESCRIPTION
…wrap

This will avoid text overflowing the parent element width.
e.g. list items