### PR TITLE
Imp: modern - do not load dev classes when CZR_DEV and as customizr-pro

### DIFF
--- a/core/init.php
+++ b/core/init.php
@@ -321,7 +321,7 @@ if ( ! class_exists( 'CZR___' ) ) :
             }
 
             //load the new framework classes
-            if ( CZR_DEV_MODE ) {
+            if ( !CZR_IS_PRO && CZR_DEV_MODE ) {
                 $this -> czr_fn_require_once( CZR_FRAMEWORK_PATH . 'class-model.php' );
                 $this -> czr_fn_require_once( CZR_FRAMEWORK_PATH . 'class-collection.php' );
                 $this -> czr_fn_require_once( CZR_FRAMEWORK_PATH . 'class-view.php' );


### PR DESCRIPTION
since we do not deploy them.
This will avoid us to always toggle the CZR_DEV constant when switching
from customizr to customizr-pro