### PR TITLE
Imp: make sure the_author_description filter hook is fired

### DIFF
--- a/assets/front/scss/0_4_layout/_article.scss
+++ b/assets/front/scss/0_4_layout/_article.scss
@@ -31,7 +31,7 @@
   .featurette-divider {
     margin-top: 1.8*$base-line-height;
   }
-  .author-bio {
+  .author-bio p:last-child{
     margin-bottom: 0;
   }
 }
@@ -374,7 +374,7 @@ section[class^="post-"] {
           text-align: left;
           margin-left: 120px;
         }
-        p {
+        .post-author-description {
           color: $grey-dark;
         }
         //@media (max-width: 992px)

--- a/core/front/models/content/post-lists/headings/class-model-archive_heading.php
+++ b/core/front/models/content/post-lists/headings/class-model-archive_heading.php
@@ -91,8 +91,8 @@ class CZR_archive_heading_model_class extends CZR_Model {
       return '';
 
     switch ( $context ) {
-      case 'author'         : return sprintf( '<span class="author-avatar">%1$s</span><p class="author-bio">%2$s</p>',
-                                        get_avatar( get_the_author_meta( 'user_email' ), 60 ) , get_the_author_meta( 'description' ) );
+      case 'author'         : return sprintf( '<span class="author-avatar">%1$s</span><div class="author-bio">%2$s</div>',
+                                        get_avatar( get_the_author_meta( 'user_email' ), 60 ) , apply_filters( 'the_author_description', get_the_author_meta( 'description' ) ) );
       case 'category'       : return category_description();
       case 'tag'            : return tag_description();
       case 'tax'            : return get_the_archive_description();

--- a/inc/_dev/parts/class-content-headings.php
+++ b/inc/_dev/parts/class-content-headings.php
@@ -365,7 +365,7 @@ if ( ! class_exists( 'CZR_headings' ) ) :
 
                   apply_filters( 'tc_author_meta_wrapper_class', 'row-fluid' ),
 
-                  sprintf('<div class="%1$s">%2$s</div><div class="%3$s"><h2>%4$s</h2><p>%5$s</p></div>',
+                  sprintf('<div class="%1$s">%2$s</div><div class="%3$s"><h2>%4$s</h2><div>%5$s</div></div>',
                       apply_filters( 'tc_author_meta_avatar_class', 'comment-avatar author-avatar span2'),
                       get_avatar( get_the_author_meta( 'user_email', $user_id ), apply_filters( 'tc_author_bio_avatar_size' , 100 ) ),
                       apply_filters( 'tc_author_meta_content_class', 'author-description span10' ),

--- a/inc/_dev/parts/class-content-post.php
+++ b/inc/_dev/parts/class-content-post.php
@@ -143,10 +143,10 @@ if ( ! class_exists( 'CZR_post' ) ) :
                                     apply_filters( 'tc_author_meta_avatar_class', 'comment-avatar author-avatar span2'),
                                     get_avatar( get_the_author_meta( 'user_email', $author_id ), apply_filters( 'tc_author_bio_avatar_size' , 100 ) )
                             ),
-                            sprintf('<div class="%1$s"><h3>%2$s</h3><p>%3$s</p><div class="author-link">%4$s</div></div>',
+                            sprintf('<div class="%1$s"><h3>%2$s</h3><div>%3$s</div><div class="author-link">%4$s</div></div>',
                                     apply_filters( 'tc_author_meta_content_class', 'author-description span10' ),
                                     sprintf( __( 'About %s' , 'customizr' ), $author_name ),
-                                    get_the_author_meta( 'description', $author_id ),
+                                    apply_filters( 'the_author_description', get_the_author_meta( 'description', $author_id ) ),
                                     sprintf( '<a href="%1$s" rel="author">%2$s</a>',
                                       esc_url( get_author_posts_url( $author_id ) ),
                                       sprintf( __( 'View all posts by %s <span class="meta-nav">&rarr;</span>' , 'customizr' ), $author_name )

--- a/templates/parts/content/singular/authors/author_info.php
+++ b/templates/parts/content/singular/authors/author_info.php
@@ -14,8 +14,8 @@
       <span class="author-avatar"><?php echo get_avatar( get_the_author_meta( 'user_email', $author_id ), 120 ) ?></span>
       <figcaption>
         <h5 class="post-author-name author_name"><?php echo get_the_author_meta( 'display_name', $author_id ) ?></h5>
-        <p><?php echo get_the_author_meta( 'description', $author_id ) ?></p>
-        <a href="<?php echo esc_url( get_author_posts_url( $author_id ) ) ?>" rel="author" class="action-link" title="<?php _e('View all the posts of the author', 'customizr'); ?>">
+        <div class="post-author-description"><?php the_author_meta( 'description', $author_id ) ?></div>
+        <a href="<?php echo esc_url( get_author_posts_url( $author_id ) ) ?>" rel="author" class="action-link" title="<?php _e( 'View all the posts of the author', 'customizr' ) ?>">
           <?php
             $author_posts = count_user_posts( $author_id );
             printf( _n('%s post', '%s posts', $author_posts , 'customizr' ), $author_posts );
@@ -23,8 +23,9 @@
         </a>
         <!-- fake need to have social links somewhere -->
         <?php
-          if ( czr_fn_is_registered_or_possible( 'author_socials' ) )
+          if ( czr_fn_is_registered_or_possible( 'author_socials' ) ) {
             czr_fn_render_template( 'modules/common/social_block', array( 'model_id' => 'author_socials' ) );
+          }
         ?>
       </figcaption>
     </figure>


### PR DESCRIPTION
when displaying the author description.
This would improve compatibility with plugins which will use that filter
hook for various reasons: e.g. to autop the author description.
Because of this, we don't wrap the author description in a <p> html tag,
it's now wrapped in a more versatile <div> html tag.

fixes #1561