### PR TITLE
Imp: modern - hide main slider nav arrows in mobile with CSS only

### DIFF
--- a/assets/front/scss/0_3_components/_slider.scss
+++ b/assets/front/scss/0_3_components/_slider.scss
@@ -61,6 +61,13 @@
     height: 100%;
     overflow: hidden;
   }
+  // hide nav in mobile
+  // @media (max-width: 575px)
+  @include media-breakpoint-down(xs) {
+    .czr-carousel-nav {
+      display: none;
+    }
+  }
 }
 
 .czr-slider-holder {

--- a/core/front/models/modules/slider/class-model-slider.php
+++ b/core/front/models/modules/slider/class-model-slider.php
@@ -66,7 +66,7 @@ class CZR_slider_model_class extends CZR_Model {
     $inner_attrs        = $this -> czr_fn_get_slider_inner_attrs();
 
     //set-up controls
-    if ( apply_filters('czr_show_slider_controls' , ! wp_is_mobile() && count( $slides ) > 1) ) {
+    if ( apply_filters( 'czr_show_slider_controls' , count( $slides ) > 1 ) ) {
       $left_control_class  = ! is_rtl() ? 'control-left' : 'control-right';
       $right_control_class = ! is_rtl() ? 'control-right' : 'control-left';
       $has_controls        = true;


### PR DESCRIPTION
fixes #1680