### PR TITLE
Fix: classic - add block editor style for the theme classical style

### DIFF
--- a/core/_dev/_admin/class-fire-admin_init.php
+++ b/core/_dev/_admin/class-fire-admin_init.php
@@ -212,10 +212,12 @@ if ( ! class_exists( 'CZR_admin_init' ) ) :
       //a) child-themes cannot override it
       //b) no check on the file existence will be made (producing the rtl error, for instance : https://github.com/presscustomizr/customizr/issues/926)
 
-      //as of v4.0.10 the editor-style.css is for classic
-      //4.1.23 block editor style introduced for the modern style only
+      //as of v4.0.10 the editor-style.css is the classic editor style for the Customizr classic style
+      //4.1.23 block editor style introduced for the Customizr modern style only
+
+      //as of 4.1.38 block editor style introduced for the Customizr modern style too
       $_style_suffix = CZR_DEBUG_MODE || CZR_DEV_MODE ? '.css' : '.min.css' ;
-      $_stylesheets = czr_fn_is_ms() ? array( CZR_ASSETS_PREFIX . 'back/css/block-editor-style' . $_style_suffix ) : array( CZR_ASSETS_PREFIX . 'back/css/editor-style' . $_style_suffix );
+      $_stylesheets = czr_fn_is_ms() ? array( CZR_ASSETS_PREFIX . 'back/css/block-editor-style' . $_style_suffix ) : array( CZR_ASSETS_PREFIX . 'back/css/editor-style' . $_style_suffix, CZR_ASSETS_PREFIX . 'back/css/block-editor-style-cs' . $_style_suffix );
 
       $_stylesheets[] = 'style.css';
       if ( ! czr_fn_is_ms() ) {

--- a/core/class-fire-init.php
+++ b/core/class-fire-init.php
@@ -198,8 +198,6 @@ if ( ! class_exists( 'CZR_init' ) ) :
           add_theme_support( 'html5', array( 'comment-form', 'caption' ) );
           // gutenberg alignwide/full cover images.
           add_theme_support( 'align-wide' );
-          // Add support for Block editor styles.
-          add_theme_support( 'editor-styles' );
 
           //tag cloud - same font size
           add_filter( 'widget_tag_cloud_args'               , array( $this, 'czr_fn_add_widget_tag_cloud_args' ));

--- a/core/init-base.php
+++ b/core/init-base.php
@@ -341,6 +341,9 @@ if ( ! class_exists( 'CZR_BASE' ) ) :
             // Add support for Gutenberg responsive embeds
             add_theme_support( 'responsive-embeds' );
 
+            // Add support for Block editor styles.
+            add_theme_support( 'editor-styles' );
+
             //post thumbnails for featured pages and post lists (archive, search, ...)
             $tc_thumb_size    = apply_filters( 'tc_thumb_size' , CZR___::$instance -> tc_thumb_size );
             add_image_size( 'tc-thumb' , $tc_thumb_size['width'] , $tc_thumb_size['height'], $tc_thumb_size['crop'] );


### PR DESCRIPTION
in order to only enlarge the editor
fixes presscustomizr#1728