### PR TITLE
Fix: modern - fix reponsive wrapper "breaking" video post formats

### DIFF
--- a/assets/front/scss/0_4_layout/_grid.scss
+++ b/assets/front/scss/0_4_layout/_grid.scss
@@ -686,7 +686,13 @@ a.czr-format-link {
       height:100%;
   }
 }
-
+// self hosted video alignment in alternate grid layout
+.czr__r-i .wp-video {
+  min-height: 100%;
+  width: 100% !important;
+  @include display-flex()
+  @include flex-align-items-center();
+}
 
 .grid-container__alternate {
   .format-audio .audio-container:not(.soundcloud)  {

--- a/core/front/models/content/common/media/class-model-video.php
+++ b/core/front/models/content/common/media/class-model-video.php
@@ -67,6 +67,7 @@ class CZR_video_model_class extends CZR_Model {
       function czr_fn_setup_late_properties() {
 
             if ( is_null( $this->media ) ) {
+
                   $this -> czr_fn_setup( array(
                         'post_id'         => $this->post_id,
                         'element_class'   => $this->element_class
@@ -123,9 +124,23 @@ class CZR_video_model_class extends CZR_Model {
             //embed
             if ( $resource ) {
                   global $wp_embed;
-                  return $wp_embed->run_shortcode( '[embed]' . esc_url( $resource[ self::$meta_fields[ 'url' ] ] ) . '[/embed]' );
-            }
+                  $video_html = $wp_embed->run_shortcode( '[embed]' . esc_url( $resource[ self::$meta_fields[ 'url' ] ] ) . '[/embed]' );
 
+                  // check whether or not we can allow a responsive wrapper
+                  // see: https://github.com/presscustomizr/customizr/issues/1742
+
+                  // first we check if we've been instructed to have a responsive wrapper
+                  if ( FALSE !== strpos( $this->element_class, 'czr__r-w' ) ) {
+                        // check if the video html starts with an iframe => its responsiveness is well handled via CSS
+                        if (  0 !== stripos( trim( $video_html ), '<iframe' ) ) {
+                              // if we cannot have a responsive wrapper, let's remove the reponsive class
+                              $this->element_class = preg_replace( '/(^|\s)czr__r-w([\S]+)/', '', $this->element_class );
+                        }
+                  }
+
+                  return $video_html;
+            }
+            error_log( );
             return false;
 
       }
@@ -153,6 +168,5 @@ class CZR_video_model_class extends CZR_Model {
 
             return false;
       }
-
 
 }

--- a/core/front/models/content/common/media/class-model-video.php
+++ b/core/front/models/content/common/media/class-model-video.php
@@ -140,7 +140,7 @@ class CZR_video_model_class extends CZR_Model {
 
                   return $video_html;
             }
-            error_log( );
+
             return false;
 
       }


### PR DESCRIPTION
when using self-hosted or facebook video URLs
we now handle only the responsiveness embeds which are iframes
fixes #1742