### PR TITLE
Fix: modern - remove offset for 2nd level submenu in desktops

### DIFF
--- a/assets/front/scss/0_2_header/_common.scss
+++ b/assets/front/scss/0_2_header/_common.scss
@@ -244,7 +244,7 @@
         font-size:ms(0);
 
         @at-root .regular-nav .dropdown-menu .dropdown-menu {
-          top: 15px;
+          top: 0;
         }
 
     }


### PR DESCRIPTION
fixes #1748